### PR TITLE
fix: Correct incentive deletion issue #77 

### DIFF
--- a/src/admin-portal/create-campaign/create-technology/Incentives.jsx
+++ b/src/admin-portal/create-campaign/create-technology/Incentives.jsx
@@ -12,8 +12,7 @@ import { useBubblyBalloons } from "../../../lib/bubbly-balloon/use-bubbly-balloo
 let incentiveToDelete = null;
 
 const Incentives = ({}) => {
-  const { technology, handleAddOverview, handleRemoveOverview } =
-    useTechnologyContext();
+  const { technology, handleAddOverview, handleRemoveOverview } = useTechnologyContext();
   const incentives = technology?.overview || [];
 
   const { notify } = useBubblyBalloons();
@@ -37,10 +36,11 @@ const Incentives = ({}) => {
   const handleRemove = async () => {
     try {
       setLoading(true);
-      const res = await removeTechnologyIncentive({ id: incentiveToDelete?.id });
+      const res = await removeTechnologyIncentive(incentiveToDelete);
 
       if (res) {
-        handleRemoveOverview(incentiveToDelete?.id);
+
+        handleRemoveOverview(incentiveToDelete);
         setShowDeleteModal(false);
         notify({
           title: "Success",
@@ -84,7 +84,7 @@ const Incentives = ({}) => {
                 <IncentivesBar
                   incentive={incentive}
                   onRemove={() => {
-                    incentiveToDelete = incentive;
+                    incentiveToDelete = { id : incentive?.id };
                     setShowDeleteModal(true);
                   }}
                 />

--- a/src/hooks/use-previous.js
+++ b/src/hooks/use-previous.js
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export default function usePrevious(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/src/views/technology-edit-view.js
+++ b/src/views/technology-edit-view.js
@@ -12,6 +12,7 @@ import BackButton from "../components/admin-components/BackButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLink } from "@fortawesome/free-solid-svg-icons";
 import { HorizontalPushLoader } from "../components/horizontal-push-loader/horizontal-push-loader";
+import usePrevious from "../hooks/use-previous";
 
 const INFO_INITIAL_STATE = {
   name: "",
@@ -86,13 +87,15 @@ export function TechnologyEditView () {
     },
   );
 
+  const prevTechnologyData = usePrevious(technologyData);
+
   useEffect(() => {
-    if (technologyData) {
+    if (prevTechnologyData === undefined && technologyData !== undefined) {
       setTechObject(technologyData);
       setNewTechnologyDetails(technologyData);
       inflate(technologyData);
     }
-  }, [technologyData, setNewTechnologyDetails]);
+  }, [prevTechnologyData, technologyData, setNewTechnologyDetails]);
 
   const notifyError = (message) => {
     notify({


### PR DESCRIPTION
Streamlined the incentive removal process in admin portal by passing the entire incentive object rather than its ID. Introduced a new custom hook 'usePrevious' for tracking previous state value. The hook has been utilized in 'TechnologyEditView' to enhance efficiency by avoiding unnecessary reactions upon the initial load of data.