### PR TITLE
Add customization option for Info section

### DIFF
--- a/src/admin-portal/create-campaign/create-technology/Info.jsx
+++ b/src/admin-portal/create-campaign/create-technology/Info.jsx
@@ -171,6 +171,20 @@ function Info({
           </Col>
         </Row>
       </form>
+      {isEditing && (<div className="py-5">
+          <CustomAccordion
+          title={"Customize The Title and Description of Info Section"}
+           component={<SectionForm
+          section="more_info_section"
+          data={techObject?.more_info_section || {}}
+          updateTechObject={({ more_info_section }) => updateTechObject(more_info_section)}
+          tech_id={tech_id}
+        />}
+        isOpen={openAccordion}
+        onClick={() => setOpenAccordion(!openAccordion)}
+      />
+    </div>)
+}
     </div>
   );
 }


### PR DESCRIPTION
This pull request adds a customization option for the Info section. It includes a new form component that allows users to customize the title and description of the Info section.