### PR TITLE
fix: Change NODE_ENV reference to TARGET_ENV in environment configura…

### DIFF
--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,4 +1,4 @@
-const ENV = process.env.NODE_ENV || 'development';
+const ENV = process.env.TARGET_ENV || 'development';
 
 console.log('ENV', ENV);
 


### PR DESCRIPTION
…tion

The NODE_ENV reference has been replaced with TARGET_ENV in the environment configuration file, src/config/environment.js, for improved clarity and consistency. This particular change aims to enforce the correct use of environmental variables, especially while distinguishing between production, canary, development, and local environments.