### PR TITLE
Update navigation and code cleanup in campaign creation

### DIFF
--- a/src/admin-portal/create-campaign/start-campaign.jsx
+++ b/src/admin-portal/create-campaign/start-campaign.jsx
@@ -10,10 +10,13 @@ import { MultiSelect } from "react-multi-select-component";
 import { useBubblyBalloons } from "../../lib/bubbly-balloon/use-bubbly-balloons";
 import { useSelector } from "react-redux";
 import { useCampaignContext } from "../../hooks/use-campaign-context";
+import { useNavigate } from "react-router-dom";
 
 export function StartCampaign ({ step, setStep, }) {
   const [showError, setShowError] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  const navigate = useNavigate()
 
   const initialState = {
     title: "",
@@ -62,7 +65,7 @@ export function StartCampaign ({ step, setStep, }) {
     try {
       setLoading(true);
       const payload = {
-        campaign_account_id: account?.id, // TODO Remove this when the API is fixed
+        campaign_account_id: account?.id,
         title: campaignDetails?.title,
         community_ids: campaignDetails?.communities?.map((community) => community?.id),
       }
@@ -99,20 +102,20 @@ export function StartCampaign ({ step, setStep, }) {
               label: manager?.name
             }
           }),
-          partners: campaign?.partners?.map((partner) => {
-            return {
-              ...partner,
-              value: partner?.id,
-              label: partner?.name
-            }
-          }),
-          events: campaign?.events?.map((event) => {
-            return {
-              ...event,
-              value: event?.id,
-              label: event?.name
-            }
-          })
+          // partners: campaign?.partners?.map((partner) => {
+          //   return {
+          //     ...partner,
+          //     value: partner?.id,
+          //     label: partner?.name
+          //   }
+          // }),
+          // events: campaign?.events?.map((event) => {
+          //   return {
+          //     ...event,
+          //     value: event?.id,
+          //     label: event?.name
+          //   }
+          // })
         })
 
         const toast = blow({
@@ -123,7 +126,9 @@ export function StartCampaign ({ step, setStep, }) {
           timeout: 5000,
         });
 
-        setStep("COMPLETE");
+        navigate(`/admin/campaign/${campaign?.slug}/edit`)
+
+        // setStep("COMPLETE");
       }
     } catch (e) {
       setLoading(false);

--- a/src/admin-portal/pages/campaign/new.js
+++ b/src/admin-portal/pages/campaign/new.js
@@ -28,11 +28,12 @@ export function NewCampaign () {
     <AdminLayout>
       <CampaignProvider>
         <div className={""}>
-          { STEP === "START" ? (<StartCampaign step={STEP} setStep={setStep}/>) : null }
 
-          {
-            STEP === "COMPLETE" ? (<CampaignEditView data={campaignDetails} STEP={STEP} setStep={setStep}/>) : null
-          }
+          <StartCampaign step={STEP} setStep={setStep}/>
+
+          {/*{*/}
+          {/*  STEP === "COMPLETE" ? (<CampaignEditView data={campaignDetails} STEP={STEP} setStep={setStep}/>) : null*/}
+          {/*}*/}
         </div>
       </CampaignProvider>
     </AdminLayout>

--- a/src/contexts/campaign-context.js
+++ b/src/contexts/campaign-context.js
@@ -94,15 +94,15 @@ export function CampaignProvider ({ children }) {
     return await fetchAllTechnologies(getAccFromLocalStorage());
   }, { ...SWR_CONFIG, });
 
-  const {
-    // initialData: allPartnersInitialData,
-    data: allPartners,
-    error: allPartnersError,
-    isValidating: allPartnersIsValidating,
-    isLoading: allPartnersIsLoading,
-  } = useSWR("partners.list", async () => {
-    await fetchAllPartners("partners.list")
-  }, { ...SWR_CONFIG, });
+  // const {
+  //   // initialData: allPartnersInitialData,
+  //   data: allPartners,
+  //   error: allPartnersError,
+  //   isValidating: allPartnersIsValidating,
+  //   isLoading: allPartnersIsLoading,
+  // } = useSWR("partners.list", async () => {
+  //   await fetchAllPartners("partners.list")
+  // }, { ...SWR_CONFIG, });
 
   // const {
   //   data: allEvents,
@@ -126,12 +126,12 @@ export function CampaignProvider ({ children }) {
   // });
 
   const lists = {
-    allPartners: {
-      data: addLabelsAndValues(allPartners || []),
-      error: allPartnersError,
-      isValidating: allPartnersIsValidating,
-      isLoading: allPartnersIsLoading,
-    },
+    // allPartners: {
+    //   data: addLabelsAndValues(allPartners || []),
+    //   error: allPartnersError,
+    //   isValidating: allPartnersIsValidating,
+    //   isLoading: allPartnersIsLoading,
+    // },
     allManagers: {
       // data: allManagers,
       // error: allManagersError,


### PR DESCRIPTION
Introduced the useNavigate from "react-router-dom" to handle navigation during campaign creation process. Disabled code sections related to partners and events in the start-campaign.jsx, and allPartners' list from the campaign context. Also removed the CampaignEditView rendering based on completion status from new.js.