### PR TITLE
Add window reload after removing campaign technology

### DIFF
--- a/src/requests/campaign-requests.js
+++ b/src/requests/campaign-requests.js
@@ -368,6 +368,7 @@ export async function removeCampaignTechnology(data, url = "campaigns.technologi
       handleRequestError(response?.error, "REMOVE_CAMPAIGN_TECHNOLOGY_ERROR_BE");
     }
 
+    window.location.reload() // So many things depend on a tech so its easier to reload
     return response?.data;
   } catch (e) {
     handleRequestError(e, "REMOVE_CAMPAIGN_TECHNOLOGY_ERROR");


### PR DESCRIPTION
This pull request adds a window reload after removing campaign technology. This is necessary because many things depend on a technology, so it's easier to reload the window.