### PR TITLE
Blowing up all fonts on the entire user facing side

### DIFF
--- a/src/assets/styles/mobile-only.css
+++ b/src/assets/styles/mobile-only.css
@@ -3,7 +3,8 @@
     display: none !important;
   }
   .page-title {
-    font-size: var(--mob-title-font-size);
+    font-size: var(--app-mobile-header-font);
+    text-align: center;
     color: var(--app-accent-3);
   }
   .page-slogan {
@@ -13,7 +14,7 @@
     /* text-transform: capitalize; */
     line-height: 1.5;
     width: 85%;
-    font-size: var(--mob-normal-font-size);
+    font-size: var(--app-mobile-subheader-font);
     font-weight: 600;
   }
 
@@ -149,7 +150,7 @@
   }
 
   .section-title {
-    font-size: 1.3rem;
+    font-size: var(--app-mobile-header-font);
   }
 
   .overview-item p {
@@ -173,5 +174,22 @@
     margin-top: 40px;
     /* padding: 20px; */
   }
+
+  .body-font {
+    font-size: var(--app-mobile-body-font);
+  }
+
+  .subheader-font {
+    font-size: var(--app-mobile-subheader-font);
+  }
+
+  .header-font {
+    font-size: var(--app-mobile-header-font);
+  }
+
+  .small-font {
+    font-size: var(--app-mobile-small-font);
+  }
+
   /* ---------------------------- END OF PHONE SPECIFIC STYLES ----------- */
 }

--- a/src/assets/styles/pc-only.css
+++ b/src/assets/styles/pc-only.css
@@ -1,7 +1,7 @@
 @media only screen and (min-width: 768px) {
   .page-title {
     text-align: center;
-    font-size: 3rem;
+    font-size: var(--app-header-font);
     color: var(--app-accent-3);
     /* text-transform: uppercase; */
   }
@@ -15,7 +15,7 @@
     /* text-transform: capitalize; */
     line-height: 1.5;
     width: 85%;
-    font-size: 1.2rem;
+    font-size: var(--app-subheader-font);
     font-weight: 600;
   }
 
@@ -139,6 +139,23 @@
 
   .pc-vanish {
     display: none !important;
+  }
+
+  .section-title {
+    font-size: var(--app-header-font)
+  }
+
+  .header-font { 
+    font-size: var(--app-header-font);
+  }
+  .body-font { 
+    font-size: var(--app-body-font) !important;
+  }
+  .subheader-font { 
+    font-size: var(--app-subheader-font);
+  }
+  .small-font { 
+    font-size: var(--app-small-font);
   }
 
   /* --------------------------------- END OF PC SPECIFIC ---------------------- */

--- a/src/assets/styles/universal.css
+++ b/src/assets/styles/universal.css
@@ -7,116 +7,117 @@
 @import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
 
 * {
-    font-family: "Google Sans", sans-serif;
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+  font-family: "Google Sans", sans-serif;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    overflow-x: hidden;
+  overflow-x: hidden;
 }
 
 :root {
-    --app-main-color: #3030d0;
-    /* --app-accent-1: #00deb5; */
-    --app-accent-1: #00deb530;
-    /* --app-accent-2: #ffc501; */
-    --app-accent-2: #ffc50180;
-    --app-accent-3: #ff4b00;
-    --app-accent-4: #ff97d6;
-    --app-deep-green: #3c5b11;
-    --app-medium-green: #8bb256;
-    --app-kicking-yellow: #ffd66d;
-    --kicking-background: #fff5dd;
-    /* --app-deep-green: #3030d0;  */
-    /* --app-medium-green: #ffc501; */
-    --app-antique-white: antiquewhite;
-    --app-orange: #f57907;
-    --app-close-red: #d33f2b;
-
-    --mob-normal-font-size: 0.85rem;
-    --mob-paragraph-font-size: 0.9rem;
-    --mob-title-font-size: calc(1.325rem + 0.9vw);
-
-    --admin-theme-color: #6e207c;
-    --admin-theme-color-light: #be52d1;
+  --app-main-color: #3030d0;
+  --app-accent-1: #00deb530;
+  --app-accent-2: #ffc50180;
+  --app-accent-3: #ff4b00;
+  --app-accent-4: #ff97d6;
+  --app-deep-green: #3c5b11;
+  --app-medium-green: #8bb256;
+  --app-kicking-yellow: #ffd66d;
+  --kicking-background: #fff5dd;
+  --app-antique-white: antiquewhite;
+  --app-orange: #f57907;
+  --app-close-red: #d33f2b;
+  --mob-normal-font-size: 0.85rem;
+  --mob-paragraph-font-size: 0.9rem;
+  --mob-title-font-size: calc(1.325rem + 0.9vw);
+  --admin-theme-color: #6e207c;
+  --admin-theme-color-light: #be52d1;
+  --app-header-font: 2.5rem;
+  --app-subheader-font: 1.5rem;
+  --app-body-font: 1.2rem;
+  --app-small-font: 1rem;
+  --app-mobile-header-font: 1.3rem;
+  --app-mobile-subheader-font: 1.125rem;
+  --app-mobile-body-font: 1rem;
+  --app-mobile-small-font: 0.9rem;
 }
 
 .already-liked {
-    color: var(--app-orange) !important;
+  color: var(--app-orange) !important;
 }
 
 .touchable-opacity {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .touchable-opacity:hover {
-    opacity: 0.7;
-    transition: 0.5s;
+  opacity: 0.7;
+  transition: 0.5s;
 }
 
 .touchable-opacity:active {
-    transform: scale(0.95);
+  transform: scale(0.95);
 }
 
 .interact:active {
-    transform: scale(1);
-    color: var(--app-medium-green) !important;
+  transform: scale(1);
+  color: var(--app-medium-green) !important;
 }
 
 .interact {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .interact:hover {
-    /* animation: pulse .8s forwards; */
-    transition: 0.3s ease-out;
-    transform: scale(1.5);
+  /* animation: pulse .8s forwards; */
+  transition: 0.3s ease-out;
+  transform: scale(1.5);
 }
 
 @keyframes pulse {
-    0% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.5);
-    }
-    100% {
-        transform: scale(1);
-    }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .row-flex {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .column-flex {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .f-dropdown-override {
-    font-size: 1rem !important;
-    padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x) !important;
-    color: black !important;
+  font-size: 1rem !important;
+  padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x) !important;
+  color: black !important;
 }
 .f-dropdown-override:hover {
-    background: #f8f9fa !important;
+  background: #f8f9fa !important;
 }
 
-
 .c-nav-item {
-    color: var(--app-main-color) !important;
+  color: var(--app-main-color) !important;
 }
 
 .share-campaign-btn {
-    font-weight: bold;
-    color: var(--app-main-color);
-    border: solid 2px var(--app-main-color);
-    border-radius: 55px;
-    padding: 4px 15px;
-    margin: 5px;
+  font-weight: bold;
+  color: var(--app-main-color);
+  border: solid 2px var(--app-main-color);
+  border-radius: 55px;
+  padding: 4px 15px;
+  margin: 5px;
 }

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -9,14 +9,7 @@ const DATA = [
 const labAc = (item) => item.name;
 const valAc = (item) => item.id;
 
-function Filter ({
-  filterOptions ,
-  valueAccessor = valAc,
-  labelAccessor = labAc,
-  render,
-  contentRoot,
-  title,
-}) {
+function Filter({ filterOptions, valueAccessor = valAc, labelAccessor = labAc, render, contentRoot, title }) {
   const [selection, setSelection] = useState([]);
 
   const addToSelection = (item) => {
@@ -45,12 +38,11 @@ function Filter ({
 
   return (
     <div>
-      <div>
+      <div style={{ marginTop: 10 }}>
         <NavDropdown
           title={
-            <span style={{ fontWeight: "bold" }}>
-              <i className="fa fa-filter" style={{ marginRight: 6 }}></i>{" "}
-              {title || "Filter items by"}
+            <span className="body-font" style={{ fontWeight: "bold" }}>
+              <i className="fa fa-filter" style={{ marginRight: 6 }}></i> {title || "Filter items by"}
             </span>
           }
         >
@@ -65,12 +57,7 @@ function Filter ({
                 }}
               >
                 {getLabel(item)}
-                {isChecked && (
-                  <i
-                    className="fa fa-check"
-                    style={{ marginLeft: 6, color: "var(--app-main-color)" }}
-                  />
-                )}
+                {isChecked && <i className="fa fa-check" style={{ marginLeft: 6, color: "var(--app-main-color)" }} />}
               </NavDropdown.Item>
             );
           })}
@@ -94,20 +81,14 @@ function Filter ({
                 }}
               >
                 {getLabel(item)}
-                <i
-                  className="fa fa-times"
-                  onClick={() => addToSelection(item)}
-                  style={{ marginLeft: 6 }}
-                ></i>
+                <i className="fa fa-times" onClick={() => addToSelection(item)} style={{ marginLeft: 6 }}></i>
               </span>
             );
           })}
         </div>
       )}
 
-      <div style={{ marginTop: 15, ...(contentRoot || {}) }}>
-        {render && render(selection)}
-      </div>
+      <div style={{ marginTop: 15, ...(contentRoot || {}) }}>{render && render(selection)}</div>
     </div>
   );
 }

--- a/src/components/OurParagraph.js
+++ b/src/components/OurParagraph.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-function OurParagraph ({ children, className }) {
-  return <p className={`paragraph-font text-muted ${className || ""}`}>{children}</p>;
+function OurParagraph({ children, className }) {
+  return <p className={`body-font text-muted ${className || ""}`}>{children}</p>;
 }
 
 export default OurParagraph;

--- a/src/components/SmartRichText.js
+++ b/src/components/SmartRichText.js
@@ -2,14 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 const DEFAULT_MAX = 150;
 const PADDING = 15;
-function SmartRichText({
-  text,
-  richText,
-  children,
-  maxHeight = DEFAULT_MAX,
-  style,
-  renderSeeMore,
-}) {
+function SmartRichText({ text, richText, children, maxHeight = DEFAULT_MAX, style, renderSeeMore, className }) {
   const ref = useRef();
   const [stashedHeight, setStashedHeight] = useState(0);
   const [displayHeight, setDisplayHeight] = useState(maxHeight);
@@ -42,7 +35,7 @@ function SmartRichText({
 
     return (
       <small
-        className="touchable-opacity"
+        className="touchable-opacity small-font"
         style={{
           fontWeight: "bold",
           color: "var(--app-accent-3)",
@@ -57,6 +50,7 @@ function SmartRichText({
   return (
     <>
       <div
+        className={` ${className || ""}`}
         style={{
           padding: `${PADDING}px 0px`,
           //   padding: `15px 0px`,

--- a/src/components/modal/CustomModal.js
+++ b/src/components/modal/CustomModal.js
@@ -72,7 +72,7 @@ const SmartHeader = ({ renderHeader, close, title, imgSrc, iconName }) => {
         }}
       >
         {renderHeaderMedia()}
-        <Modal.Title id="contained-modal-title-vcenter" style={{ fontSize: 18 }}>
+        <Modal.Title id="contained-modal-title-vcenter body-font">
           {title || "..."}
         </Modal.Title>
       </div>

--- a/src/components/navbar/AppNavigationBar.js
+++ b/src/components/navbar/AppNavigationBar.js
@@ -40,7 +40,7 @@ function AppNavigationBar({ menu, campaign }) {
               if (!menu?.children)
                 return (
                   <Nav.Link
-                    className="c-nav-item"
+                    className="c-nav-item body-font"
                     key={menu?.key}
                     style={{
                       textTransform: "capitalize",
@@ -64,7 +64,7 @@ function AppNavigationBar({ menu, campaign }) {
                     marginRight: 20,
                     fontWeight: "bold",
                   }}
-                  className={"mx-2"}
+                  className={"mx-2 body-font"}
                   title={
                     <span className="c-nav-item">
                       <i className={`fa ${menu.icon}`} style={{ marginRight: 6 }}></i>

--- a/src/components/pieces/Loading.js
+++ b/src/components/pieces/Loading.js
@@ -19,8 +19,9 @@ function Loading({ text = "Loading...", fullPage, children, spinnerStyle }) {
       };
   return (
     <div style={styles}>
-      <Spinner style={{ ...(spinnerStyle || {}) }} animation="border"/>
+      <Spinner style={{ ...(spinnerStyle || {}) }} animation="border" />
       <small
+        className="small-font"
         style={{
           margin: 10,
           fontWeight: "bold",

--- a/src/index.css
+++ b/src/index.css
@@ -2,35 +2,35 @@
 @import url(./assets/styles/universal.css);
 
 body {
-	font-family: "Manrope", sans-serif;
+  font-family: "Manrope", sans-serif;
 }
 
 .table-trashcan {
-	padding: 0.5rem;
-	/* width: 2rem;
+  padding: 0.5rem;
+  /* width: 2rem;
 	height: 2rem; */
-	font-size: 0.875rem;
-	border-radius: 9999px;
-	transition-property: all;
-	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	transition-duration: 300ms;
-	transition-duration: 300ms;
-	box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-	text-align: center;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+  font-size: 0.875rem;
+  border-radius: 9999px;
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+  transition-duration: 300ms;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .table-trashcan:hover {
-	background-color: red;
-	color: white;
+  background-color: red;
+  color: white;
 }
 .tech-btn {
-	border-radius: 500px !important;
-	padding: 8px 23px !important;
-	margin: 6px;
-	font-size: 12px !important;
-	border-width: 0px !important;
-	font-weight: bold !important;
-  }
+  border-radius: 500px !important;
+  padding: 8px 23px !important;
+  margin: 6px;
+  font-size: var(--small-font) !important;
+  border-width: 0px !important;
+  font-weight: bold !important;
+}

--- a/src/user-portal/pages/coaches/CoachesSectionWithFilters.js
+++ b/src/user-portal/pages/coaches/CoachesSectionWithFilters.js
@@ -96,7 +96,7 @@ function CoachesSectionWithFilters({ toggleModal, sectionId, technologies, custo
 
             <div className="coaches-description">
               {customization?.description && (
-                <div dangerouslySetInnerHTML={{ __html: customization?.description }}></div>
+                <div className="body-font" dangerouslySetInnerHTML={{ __html: customization?.description }}></div>
               )}
               <div
                 style={{

--- a/src/user-portal/pages/coaches/CoachesSectionWithFilters.js
+++ b/src/user-portal/pages/coaches/CoachesSectionWithFilters.js
@@ -9,6 +9,7 @@ import Filter from "../../../components/Filter";
 import OurParagraph from "../../../components/OurParagraph";
 import { ArrowButtons } from "../../../components/pieces/ArrowButtons";
 import { mergeArrays } from "../../../utils/utils";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 function CoachesSectionWithFilters({ toggleModal, sectionId, technologies, customization }) {
   const containerRef = useRef();
@@ -66,7 +67,9 @@ function CoachesSectionWithFilters({ toggleModal, sectionId, technologies, custo
           <div>
             <div className="row-flex t-with-filter-top">
               <div>
-                <h2
+                <SectionTitle style={{ color: "black" }}>{customization?.title || " Meet the coaches"}</SectionTitle>
+                {/* <h2
+                  className="header-font"
                   style={{
                     color: "black",
                     fontWeight: "bold",
@@ -75,7 +78,7 @@ function CoachesSectionWithFilters({ toggleModal, sectionId, technologies, custo
                   }}
                 >
                   {customization?.title || " Meet the coaches"}
-                </h2>
+                </h2> */}
                 {/* <OurParagraph>
                   Scroll from left to right to see more coaches, or use the arrow buttons(top right) to scroll
                 </OurParagraph> */}

--- a/src/user-portal/pages/coaches/OneCoach.js
+++ b/src/user-portal/pages/coaches/OneCoach.js
@@ -12,8 +12,8 @@ function OneCoach({ full_name, image, community }) {
       }}
     >
       <img className="" src={image?.url || noCoach} alt={"logo"}></img>
-      <h6 className="">{full_name}</h6>
-      <p className="" style={{  }}>
+      <h6 className="body-font">{full_name}</h6>
+      <p className="small-font" style={{}}>
         {community}
       </p>
     </div>

--- a/src/user-portal/pages/commenting/CommentComponentForModal.js
+++ b/src/user-portal/pages/commenting/CommentComponentForModal.js
@@ -116,11 +116,16 @@ function CommentComponentForModal({
 
           const isForCurrentUser = commentIsForUser(com, authUser);
           return (
-            <div className="mb-2 mt-1 pb-2" style={{ border: "solid 0px #f5f5f5", borderBottomWidth: 1 }} key={com?.id}>
+            <div
+              className="mb-2 mt-1 pb-2 "
+              style={{ border: "solid 0px #f5f5f5", borderBottomWidth: 1 }}
+              key={com?.id}
+            >
               <h6
+                className="small-font"
                 style={{
                   // textDecoration: "underline",
-                  fontSize: 14,
+                  // fontSize: 14,
                   fontWeight: "bold",
                   color: !isForCurrentUser ? "var(--app-main-color)" : "var(--app-accent-3)",
                 }}
@@ -131,7 +136,7 @@ function CommentComponentForModal({
                 {community && " from "}
                 <span style={{ color: "var(--app-medium-green)" }}>{community} </span>
               </h6>
-              <small>{message}</small>
+              <small className="small-font">{message}</small>
               <small
                 style={{
                   width: "100%",

--- a/src/user-portal/pages/events/EventBox.js
+++ b/src/user-portal/pages/events/EventBox.js
@@ -32,7 +32,7 @@ function EventBox({ event, campaign_technology }) {
       )}
       <div style={{ padding: "15px 15px" }}>
         <h6
-          className="touchable-opacity"
+          className="touchable-opacity body-font"
           role={"button"}
           tabIndex={0}
           onClick={() => navigator(`/campaign/${campaign?.slug}/technology/event/${id}`)}
@@ -52,9 +52,10 @@ function EventBox({ event, campaign_technology }) {
         </h6>
 
         <p
+          className="small-font"
           style={{
             marginTop: 15,
-            fontWeight: "bold",
+            // fontWeight: "bold",
             color: "var(--app-accent-3)",
           }}
         >

--- a/src/user-portal/pages/events/EventsSectionWithFilters.js
+++ b/src/user-portal/pages/events/EventsSectionWithFilters.js
@@ -7,6 +7,7 @@ import Filter from "../../../components/Filter";
 import { mergeArrays } from "../../../utils/utils";
 import { ArrowButtons } from "../../../components/pieces/ArrowButtons";
 import OurParagraph from "../../../components/OurParagraph";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 function EventsSectionWithFilters({ sectionId, technologies }) {
   const containerRef = useRef();
@@ -18,9 +19,7 @@ function EventsSectionWithFilters({ sectionId, technologies }) {
     if (filters?.length)
       data = events?.filter((ev) => {
         // const techsRelatedToEvent = ev?.campaign_technology?.map((t) => t.id); // pick only the campaign technology ids
-        return filters.some(
-          (f) => f.campaign_technology_id === ev?.campaign_technology?.id,
-        );
+        return filters.some((f) => f.campaign_technology_id === ev?.campaign_technology?.id);
       });
     else data = events;
 
@@ -60,7 +59,9 @@ function EventsSectionWithFilters({ sectionId, technologies }) {
       <CenteredWrapper>
         <Container>
           <div className="row-flex t-with-filter-top">
-            <h2
+            <SectionTitle>Events</SectionTitle>
+            {/* <h2
+
               style={{
                 color: "var(--app-accent-3)",
                 fontWeight: "bold",
@@ -68,7 +69,7 @@ function EventsSectionWithFilters({ sectionId, technologies }) {
               }}
             >
               Events
-            </h2>
+            </h2> */}
 
             {hasScrollableEvents && <ArrowButtons containerRef={containerRef} style={{ marginLeft: "auto" }} />}
           </div>

--- a/src/user-portal/pages/events/OneEvent.js
+++ b/src/user-portal/pages/events/OneEvent.js
@@ -66,7 +66,7 @@ function OneEvent({ events, updateEvents, init, campaign }) {
             alt={"event"}
           />
 
-          <p className="mt-4" style={{ textAlign: "justify" }}>
+          <p className="mt-4 body-font" style={{ textAlign: "justify" }}>
             <span
               dangerouslySetInnerHTML={{ __html: description }}
               style={{ display: "block", overflowY: "hidden" }}
@@ -75,8 +75,12 @@ function OneEvent({ events, updateEvents, init, campaign }) {
         </Col>
         <Col lg={3} className="mt-2">
           <div>
-            <h6 style={{ color: "black", fontWeight: "bold" }}>Date</h6>
-            <small>{formatTimeRange(start_date_and_time, end_date_and_time)}</small>
+            <h6 className="body-font text-muted" style={{ fontWeight: "" }}>
+              Date
+            </h6>
+            <small className="small-font" style={{ fontWeight: "bold" }}>
+              {formatTimeRange(start_date_and_time, end_date_and_time)}
+            </small>
           </div>
 
           {external_link && (
@@ -85,7 +89,7 @@ function OneEvent({ events, updateEvents, init, campaign }) {
                 e.preventDefault();
                 window.open(external_link || "#", "_blank");
               }}
-              className="mt-2 touchable-opacity"
+              className="mt-2 touchable-opacity body-font"
               style={{
                 background: "var(--app-main-color)",
                 padding: 10,

--- a/src/user-portal/pages/footer/Footer.js
+++ b/src/user-portal/pages/footer/Footer.js
@@ -114,9 +114,10 @@ function Footer({ toggleModal, campaign, authUser }) {
             </Button>
             {user?.email && (
               <p
+                className="small-font"
                 style={{
                   marginTop: 10,
-                  fontSize: 12,
+                  // fontSize: 12,
                   color: "#e1efce",
                 }}
               >

--- a/src/user-portal/pages/footer/Footer.js
+++ b/src/user-portal/pages/footer/Footer.js
@@ -34,7 +34,7 @@ function Footer({ toggleModal, campaign, authUser }) {
         <li
           role={"button"}
           tabIndex={0}
-          className="touchable-opacity"
+          className="touchable-opacity small-font"
           onClick={() => {
             if (newTab) return window.open(url, "_blank");
             navigator(`${url}&salt=${salt}`);
@@ -90,8 +90,10 @@ function Footer({ toggleModal, campaign, authUser }) {
         <Container>
           <Col lg={{ span: 6, offset: 3 }}>
             {/* We should be able to change this part tooo from the admin portal */}
-            <h4 style={{ color: "white" }}>{customization?.title || "Newsletter"}</h4>
-            <p style={{ color: "white" }}>
+            <h4 className="subheader-font" style={{ color: "white" }}>
+              {customization?.title || "Newsletter"}
+            </h4>
+            <p className="body-font" style={{ color: "white" }}>
               {customization?.description || "Sign up for email updates with the latest info on events and incentives!"}
             </p>
             <Button
@@ -139,7 +141,9 @@ function Footer({ toggleModal, campaign, authUser }) {
         <Container>
           <Row>
             <Col lg={{ span: 9, offset: 1 }} style={{}}>
-              <h4 style={{ color: "white" }}>Quick Links</h4>
+              <h4 className="subheader-font" style={{ color: "white" }}>
+                Quick Links
+              </h4>
               <ul
                 style={{
                   listStyleType: "none",
@@ -178,8 +182,10 @@ const MobileFooter = ({ signUpForNewsletter, renderMenus, customization }) => {
           flexDirection: "column",
         }}
       >
-        <h5 style={{ color: "white" }}>{customization?.title || "Newsletter"}</h5>
-        <p style={{ color: "white", fontSize: "var(--mob-normal-font-size" }}>
+        <h5 className="subheader-font" style={{ color: "white" }}>
+          {customization?.title || "Newsletter"}
+        </h5>
+        <p className="body-font" style={{ color: "white" }}>
           {customization?.description || "Sign up for email updates with the latest info on events and incentives!"}
         </p>
         <Button

--- a/src/user-portal/pages/forms/CommunitySelector.js
+++ b/src/user-portal/pages/forms/CommunitySelector.js
@@ -29,7 +29,7 @@ function CommunitySelector({ onChange, communities, data, readOnly }) {
 
   return (
     <div>
-      <Form.Text>What community do you live in?</Form.Text>
+      <Form.Text className="small-font">What community do you live in?</Form.Text>
       {/* <p>Please tell us where you are from (Editable)</p> */}
       <Form
         className="m-2 pb-2"
@@ -45,11 +45,12 @@ function CommunitySelector({ onChange, communities, data, readOnly }) {
             <Form.Check inline type="radio" id={`check-api-${id}`} className="touchable-opacity">
               <Form.Check.Input checked={comId === id?.toString()} type={"radio"} value={id} />
               <Form.Check.Label
+                className="body-font"
                 style={{
                   textTransform: "Capitalize",
-                  fontWeight: "bold",
+                  // fontWeight: "bold",
                   color: "var(--app-main-color)",
-                  fontSize: 15,
+                  // fontSize: 15,
                   cursor: "pointer",
                 }}
               >

--- a/src/user-portal/pages/forms/GetHelpForm.js
+++ b/src/user-portal/pages/forms/GetHelpForm.js
@@ -4,9 +4,10 @@ import { Button, Form, ModalFooter } from "react-bootstrap";
 import { connect } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-const DEFAULT_HELP_LINK = "https://docs.google.com/forms/d/e/1FAIpQLSeb7oZ2XRTdGWuasXmGmjjF8xAbE8jryu8SJxZlCOqWTJNKMA/viewform"; // to be provided by Amie
+const DEFAULT_HELP_LINK =
+  "https://docs.google.com/forms/d/e/1FAIpQLSeb7oZ2XRTdGWuasXmGmjjF8xAbE8jryu8SJxZlCOqWTJNKMA/viewform"; // to be provided by Amie
 
-function GetHelpForm ({ close, communities, authUser }) {
+function GetHelpForm({ close, communities, authUser }) {
   const [form, setForm] = useState({});
 
   useEffect(() => {
@@ -21,33 +22,30 @@ function GetHelpForm ({ close, communities, authUser }) {
   const onChange = (data) => {
     const isOther = data?.comId === OTHER;
     const { comId } = data || {};
-    const campaign_community = communities?.find(
-      ({ community }) => community?.id?.toString() === comId
-    );
+    const campaign_community = communities?.find(({ community }) => community?.id?.toString() === comId);
 
     setForm({
-      campaign_community: isOther
-        ? { help_link: DEFAULT_HELP_LINK }
-        : campaign_community,
       ...(data || {}),
+      campaign_community: isOther ? { help_link: DEFAULT_HELP_LINK } : campaign_community,
     });
   };
 
   const { campaign_community } = form || {};
-  const { community } = campaign_community || {};
+  const { community, alias } = campaign_community || {};
+
   const findHelp = () => {
     window.open(campaign_community?.help_link || DEFAULT_HELP_LINK, "_blank");
   };
 
-  // useEffect(() => {}, []);
+  const comName = alias || community?.name || "";
 
   return (
     <div>
       <div style={{ padding: 20 }}>
         <CommunitySelector onChange={onChange} data={form} readOnly />
-        <Form.Text>
+        <Form.Text className="small-font">
           We will direct you to the right resources based on where you are from
-          {!community?.name ? "" : `(${community?.name}) `}
+          {` ${comName}`}
         </Form.Text>
       </div>
       <ModalFooter style={{ padding: 0 }}>

--- a/src/user-portal/pages/getting-started/GettingStartedSection.js
+++ b/src/user-portal/pages/getting-started/GettingStartedSection.js
@@ -106,7 +106,7 @@ const DoMoreBox = ({ scrollToCommunities }) => {
           style={{ background: "var(--app-main-color)" }}
           className="tech-btn elevate-2 touchable-opacity"
         >
-          <span style={{ fontSize: 15 }}> Communities</span>
+          <span> Communities</span>
         </Button>
       </div>
     </div>

--- a/src/user-portal/pages/getting-started/GettingStartedSection.js
+++ b/src/user-portal/pages/getting-started/GettingStartedSection.js
@@ -2,6 +2,7 @@ import React from "react";
 import OneBox from "./OneBox";
 import { Button, Col, Container, Row } from "react-bootstrap";
 import people from "./../../../assets/imgs/g_people.png";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 const dummies = [
   {
@@ -32,18 +33,14 @@ function GettingStartedSection({
   trackActivity,
   authUser,
 }) {
-  // console.log("these are the technologies", technologies);
   return (
-    <div
-      id={sectionId}
-      className="mt-5 g-s-container"
-
-    >
+    <div id={sectionId} className="mt-5 g-s-container">
       <Container>
         <Row>
           <Col lg={{ span: 12 }}>
-            <h2 style={{ color: "white", fontWeight: "bold" }}>{customization?.title || "Getting Started"}</h2>
-            <p style={{ color: "white", marginBottom: 20 }}>
+            <SectionTitle style={{ color: "white" }}>{customization?.title || "Getting Started"}</SectionTitle>
+
+            <p className="body-font" style={{ color: "white", marginBottom: 20 }}>
               {/* This section should be edited via the admin portal */}
               {customization?.description ||
                 "Explore the actions we have under these technologies and get started right away!"}
@@ -76,21 +73,19 @@ export default GettingStartedSection;
 
 const DoMoreBox = ({ scrollToCommunities }) => {
   return (
-    <div
-      className="elevate-float-pro one-box-container"
-   
-    >
-      <div
-        className="one-box"
-      >
+    <div className="elevate-float-pro one-box-container">
+      <div className="one-box">
         <img
           // src={"https://placehold.co/100x100"}
           src={people}
           alt="people"
-         
         />
-        <h5 style={{ color: "var(--app-main-color)"  }}>Communities</h5>
-        <p style={{ textAlign: "center" }}>Connect with your community and check out other actions</p>
+        <h5 className="subheader-font" style={{ color: "var(--app-main-color)" }}>
+          Communities
+        </h5>
+        <p className="body-font" style={{ textAlign: "center" }}>
+          Connect with your community and check out other actions
+        </p>
 
         <Button
           variant={"link"}
@@ -105,9 +100,7 @@ const DoMoreBox = ({ scrollToCommunities }) => {
         </Button>
       </div>
 
-      <div
-        className="one-box-footer phone-vanish"
-      >
+      <div className="one-box-footer phone-vanish">
         <Button
           onClick={() => scrollToCommunities()}
           style={{ background: "var(--app-main-color)" }}

--- a/src/user-portal/pages/getting-started/OneBox.js
+++ b/src/user-portal/pages/getting-started/OneBox.js
@@ -79,7 +79,7 @@ function OneBox({
           className="tech-btn elevate-2 touchable-opacity mr-2"
           style={{ background: "var(--app-accent-3)", marginRight: 20 }}
         >
-          QUOTE
+          Quote
         </Button>
         <Button
           onClick={() => {
@@ -89,7 +89,7 @@ function OneBox({
           style={{ background: "var(--app-main-color)" }}
           className="tech-btn elevate-2 touchable-opacity"
         >
-          COACH
+          Coach
         </Button>
       </div>
     </div>

--- a/src/user-portal/pages/getting-started/OneBox.js
+++ b/src/user-portal/pages/getting-started/OneBox.js
@@ -50,12 +50,16 @@ function OneBox({
             // style={{ height: 100, width: 100, objectFit: "contain" }}
           />
         )}
-        <h5 style={{ textTransform: "capitalize", color: "var(--app-main-color)" }}>{name}</h5>
+        <h5 className="subheader-font" style={{ textTransform: "capitalize", color: "var(--app-main-color)" }}>
+          {name}
+        </h5>
         {/* <RenderHTML tag={"p"} html={!isEmpty(description) ? ellipsify(description, 80) : "..."} /> */}
-        <p style={{ textAlign: "center" }}>{summary?.substring(0, 80) || "..."}</p>
+        <p className="body-font" style={{ textAlign: "center" }}>
+          {summary?.substring(0, 80) || "..."}
+        </p>
         <Button
           variant={"link"}
-          className="touchable-opacity link-accent"
+          className="touchable-opacity link-accent small-font"
           // href={`/technology/${campaign_technology_id}`}
           onClick={() => {
             trackActivity && trackActivity({ ...common, button_type: "learn_more" });
@@ -66,9 +70,7 @@ function OneBox({
           Learn More...
         </Button>
       </div>
-      <div
-        className="one-box-footer phone-vanish"
-      >
+      <div className="one-box-footer phone-vanish">
         <Button
           onClick={() => {
             trackActivity && trackActivity({ ...common, button_type: "quote" });

--- a/src/user-portal/pages/landing-page/DoMore.js
+++ b/src/user-portal/pages/landing-page/DoMore.js
@@ -58,7 +58,7 @@ function DoMore({ campaign }) {
                         onClick={() => {
                           window.open(`${COMMUNITY_PORTAL_URL}${community?.subdomain}`);
                         }}
-                        className="touchable-opacity small-font"
+                        className="touchable-opacity body-font"
                         style={{
                           textDecoration: "underline",
                           color: "var(--app-accent-3)",

--- a/src/user-portal/pages/landing-page/DoMore.js
+++ b/src/user-portal/pages/landing-page/DoMore.js
@@ -1,6 +1,7 @@
 import React from "react";
 import CenteredWrapper from "../wrappers/CenteredWrapper";
 import { Col, Container, Row } from "react-bootstrap";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 function DoMore({ campaign }) {
   const { communities, communities_section } = campaign || {};
@@ -11,7 +12,8 @@ function DoMore({ campaign }) {
     <div className="do-more-root">
       <CenteredWrapper>
         <Container>
-          <h2
+          <SectionTitle>{title || " Participating Communities"}</SectionTitle>
+          {/* <h2
             style={{
               color: "black",
               fontWeight: "bold",
@@ -20,9 +22,9 @@ function DoMore({ campaign }) {
             }}
           >
             {title || " Participating Communities"}
-          </h2>
+          </h2> */}
           <p>{description}</p>
-          <Row style={{ flexWrap: "wrap", display: "flex" }}>
+          <Row style={{ flexWrap: "wrap", display: "flex", marginTop: 20 }}>
             {(communities || []).map(({ community, id, alias, extra_links: links }, index) => {
               return (
                 <Col
@@ -50,13 +52,13 @@ function DoMore({ campaign }) {
                       src={community?.logo?.url}
                       alt={"logo"}
                     />
-                    <ul style={{ padding: 0, listStyleType:'none' }}>
+                    <ul style={{ padding: 0, listStyleType: "none" }}>
                       <li
                         role={"button"}
                         onClick={() => {
                           window.open(`${COMMUNITY_PORTAL_URL}${community?.subdomain}`);
                         }}
-                        className="touchable-opacity"
+                        className="touchable-opacity small-font"
                         style={{
                           textDecoration: "underline",
                           color: "var(--app-accent-3)",

--- a/src/user-portal/pages/landing-page/RoamingBox.js
+++ b/src/user-portal/pages/landing-page/RoamingBox.js
@@ -12,12 +12,12 @@ function RoamingBox({ advert, keyContact, showMore }) {
   return (
     <div className="roaming-container">
       <Container>
-        <Col lg={{ span: 9, offset: 1 }}>
+        <Col lg={{ span: 10, offset: 1 }}>
           <Row>
             <Col lg={8}>
               <div style={{}}>
                 <div className="roaming-header">
-                  <h3 className="m-0">{advert?.title}</h3>
+                  <h3 className="m-0 subheader-font">{advert?.title}</h3>
                 </div>
                 <div
                   className="flex-column"
@@ -78,7 +78,7 @@ function RoamingBox({ advert, keyContact, showMore }) {
               </div>
             </Col>
             <Col
-              lg={{ span: 2, offset: 2 }}
+              lg={{ span: 3, offset: 1 }}
               style={{
                 display: "flex",
                 flexDirection: "column",
@@ -98,17 +98,15 @@ function RoamingBox({ advert, keyContact, showMore }) {
                 }}
                 alt={keyContact?.image?.name || "Key Contact"}
               ></img>
-              <span className="mb-1" style={{ fontSize: 12, color: "#c8c8c8" }}>
-                KEY CONTACT
-              </span>
+              <span className="mb-1 small-font text-muted">Key Contact</span>
               <h6
-                className="mb-1"
+                className="mb-1 body-font"
                 style={{
                   color: "var(--app-accent-3)",
                   fontWeight: "800",
-                  textTransform: "uppercase",
+                  textTransform: "capitalize",
                   textAlign: "center",
-                  fontSize: 15,
+                  // fontSize: 15,
                 }}
               >
                 <span>{keyContact?.name || "..."}</span>
@@ -120,7 +118,7 @@ function RoamingBox({ advert, keyContact, showMore }) {
                   onClick={() => {
                     window.open(`mailto:${keyContact?.email}`, "_blank");
                   }}
-                  className="mb-1 touchable-opacity"
+                  className="mb-1 touchable-opacity small-font"
                   style={{
                     display: "flex",
                     flexDirection: "row",
@@ -137,7 +135,7 @@ function RoamingBox({ advert, keyContact, showMore }) {
                 <p
                   role={"button"}
                   tabIndex={0}
-                  className="touchable-opacity"
+                  className="touchable-opacity small-font"
                   onClick={() => {
                     window.open(`tel:${keyContact?.phone_number}`, "_blank");
                   }}

--- a/src/user-portal/pages/landing-page/RoamingModalSheet.js
+++ b/src/user-portal/pages/landing-page/RoamingModalSheet.js
@@ -2,10 +2,9 @@ import React from "react";
 
 function RoamingModalSheet({ data }) {
   const { description } = data || {};
-  //   console.log("This is the advert data", data);
   return (
     <div>
-      <div style={{ padding: 20 }} dangerouslySetInnerHTML={{ __html: description }}></div>
+      <div className="body-font" style={{ padding: 20 }} dangerouslySetInnerHTML={{ __html: description }}></div>
     </div>
   );
 }

--- a/src/user-portal/pages/sharing/ShareBox.js
+++ b/src/user-portal/pages/sharing/ShareBox.js
@@ -67,7 +67,9 @@ function ShareBox({ data, onChange, campaign, authUser }) {
     <div>
       <div style={{ padding: 20 }}>
         <div style={{ marginBottom: 10 }}>
-          <Form.Text>Please select a platform that you would like to share this technology to</Form.Text>
+          <Form.Text className="small-font">
+            Please select a platform that you would like to share this technology to
+          </Form.Text>
         </div>
         <Form
           className="m-2 pb-2"
@@ -88,18 +90,18 @@ function ShareBox({ data, onChange, campaign, authUser }) {
                 <Form.Check className="touchable-opacity" inline type="radio" id={`check-api-${key}`}>
                   <Form.Check.Input checked={platform === key} type={"radio"} value={key} />
                   <i
-                    className={`fa ${icon}`}
+                    className={`fa ${icon} body-font`}
                     style={{
                       marginRight: 3,
-                      fontSize: 16,
+                      // fontSize: 16,
                       color: "var(--app-main-color)",
                     }}
                   ></i>
                   <Form.Check.Label
-                    className="touchable-opacity"
+                    className="touchable-opacity body-font"
                     style={{
                       // textTransform: "capitalize",
-                      fontWeight: "bold",
+                      // fontWeight: "bold",
                       fontSize: 16,
                       color: "var(--app-main-color)",
                     }}
@@ -132,7 +134,7 @@ function ShareBox({ data, onChange, campaign, authUser }) {
               {copied ? "Copied!" : "Copy Link"}
             </Button>
           </InputGroup>
-          <Form.Text>
+          <Form.Text className="small-font">
             You can copy the link and share it {state?.platform === "other" ? "" : ` on ${state.platform}`}
           </Form.Text>
         </div>

--- a/src/user-portal/pages/technology/GetAGreatDealSection.js
+++ b/src/user-portal/pages/technology/GetAGreatDealSection.js
@@ -6,7 +6,7 @@ import { Col, Row } from "react-bootstrap";
 function GetAGreatDealSection({ sectionId, data, image, deals, toggleDealModal }) {
   const { title, description, description_2 } = data || {};
   if (!Object.keys(data || {}).length) return <></>;
-  
+
   return (
     <div
       id={sectionId}
@@ -24,38 +24,22 @@ function GetAGreatDealSection({ sectionId, data, image, deals, toggleDealModal }
         <p
           dangerouslySetInnerHTML={{ __html: description }}
           style={{ textAlign: "justify" }}
-          className="mb-3 paragraph-font"
+          className="mb-3 body-font"
         ></p>
         <div className="" style={{ position: "relative" }}>
-          {/* <img
-            style={{
-              width: "100%",
-              height: 350,
-              objectFit: "cover",
-              borderRadius: 10,
-            }}
-            src={
-              image?.url ||
-              "https://picsum.photos/id/870/300/300?grayscale&blur=2"
-            }
-          /> */}
           <div
             style={{
               zIndex: 2,
-              // marginTop: -240,
-              // marginLeft: -102,
             }}
           >
             <Row style={{ margin: "50px 0px" }}>
-              {/* {[first_deal, second_deal, third_deal].map((item, index) => { */}
               {(deals || []).map((item, index) => {
                 if (!item || !item?.title) return <></>;
                 return (
                   <Col
                     onClick={() => {
                       if (item?.link) return window.open(item?.link, "_blank");
-                      if (item?.description)
-                        return toggleDealModal && toggleDealModal(item);
+                      if (item?.description) return toggleDealModal && toggleDealModal(item);
                     }}
                     className="elevate-4 touchable-opacity"
                     key={item?.id?.toString()}
@@ -73,7 +57,7 @@ function GetAGreatDealSection({ sectionId, data, image, deals, toggleDealModal }
                       marginBottom: 15,
                     }}
                   >
-                    <h3 style={{ margin: 0, color: "var(--app-accent-3)", fontSize: "1.15rem" }}>
+                    <h3 className="body-font" style={{ margin: 0, color: "var(--app-accent-3)" }}>
                       {item.title}
                     </h3>
                   </Col>

--- a/src/user-portal/pages/technology/InteractionsPanel.js
+++ b/src/user-portal/pages/technology/InteractionsPanel.js
@@ -12,13 +12,11 @@ function InteractionsPanel({ openCommentBox, likes, views, comments, openShareBo
   const [likeCount, setLikeCount] = useState(0);
 
   useEffect(() => {
-    // setHasLiked(liked);
     setLikeCount(likes);
   }, [likes, liked]);
 
   const doLike = () => {
     setLikeCount(hasLiked ? likeCount - 1 : likeCount + 1);
-    // setHasLiked(!hasLiked);
     like();
   };
 
@@ -30,7 +28,7 @@ function InteractionsPanel({ openCommentBox, likes, views, comments, openShareBo
 
   return (
     <div
-      className="mt-3"
+      className="mt-3 small-font"
       style={{
         border: "solid 2px black",
         padding: "10px 15px",
@@ -41,9 +39,7 @@ function InteractionsPanel({ openCommentBox, likes, views, comments, openShareBo
       }}
     >
       <div
-        // key={index?.toString()}
         onClick={() => {
-          // setHasLiked(!hasLiked); // Just for immediate reflection
           doLike();
         }}
         style={{
@@ -53,23 +49,14 @@ function InteractionsPanel({ openCommentBox, likes, views, comments, openShareBo
           margin: "0px 10px",
         }}
       >
-        <i
-          // className={`fa fa-heart interact ${hasLiked ? "already-liked" : ""}`}
-          className={`fa fa-heart interact`}
-          style={{ marginRight: 6, ...commonTheme }}
-        />
+        <i className={`fa fa-heart interact`} style={{ marginRight: 6, ...commonTheme }} />
 
-        <small
-          className="touchable-opacity phone-vanish"
-          // style={{ fontWeight: "bold", textDecoration: "underline" }}
-          style={{ fontWeight: "bold", ...commonTheme }}
-        >
+        <small className="touchable-opacity phone-vanish" style={{ fontWeight: "bold", ...commonTheme }}>
           {`${likeCount ? likeCount : ""} `}
           <span className="phone-vanish">{`${!likeCount || likeCount === 1 ? " Like" : " Likes"}`}</span>
         </small>
       </div>
       <div
-        // key={index?.toString()}
         onClick={() => openCommentBox && openCommentBox()}
         style={{
           display: "flex",

--- a/src/user-portal/pages/technology/MoreDetailsSection.js
+++ b/src/user-portal/pages/technology/MoreDetailsSection.js
@@ -3,7 +3,7 @@ import OptimumWrapper from "../wrappers/OptimumWrapper";
 import SectionTitle from "../../../components/pieces/SectionTitle";
 import { Col, Row } from "react-bootstrap";
 
-function MoreDetailsSection ({ sectionId, data }) {
+function MoreDetailsSection({ sectionId, data }) {
   const { title, description } = data || {};
   if (!title && !description) return <></>;
 
@@ -14,8 +14,6 @@ function MoreDetailsSection ({ sectionId, data }) {
       style={{
         background: "white",
         width: "100%",
-        // padding: "80px 0px",
-        // minHeight: 200,
       }}
     >
       <OptimumWrapper>
@@ -23,18 +21,8 @@ function MoreDetailsSection ({ sectionId, data }) {
         <p
           dangerouslySetInnerHTML={{ __html: description }}
           style={{ textAlign: "justify" }}
-          className="mb-4 paragraph-font"
+          className="mb-4 body-font"
         ></p>
-
-        {/* <img
-          style={{
-            width: "100%",
-            height: 350,
-            objectFit: "cover",
-            borderRadius: 10,
-          }}
-          src="https://picsum.photos/id/870/300/300?grayscale&blur=2"
-        /> */}
       </OptimumWrapper>
     </div>
   );

--- a/src/user-portal/pages/technology/OneTechMeetTheCoachesSetion.js
+++ b/src/user-portal/pages/technology/OneTechMeetTheCoachesSetion.js
@@ -61,11 +61,6 @@ function OneTechMeetTheCoachesSection({ toggleModal, sectionId, coaches, data, r
             <SectionTitle className="mb-5" style={{ color: "black" }}>
               {title || "Meet the Coaches"}
             </SectionTitle>
-            {/* {hasScrollableCoaches && (
-              <p style={{ fontSize: "var(--mob-paragraph-font-size)" }}>
-                Scroll from left to right, or use the arrow buttons to see all coaches
-              </p>
-            )} */}
           </div>
 
           {hasScrollableCoaches && <ArrowButtons style={{ marginLeft: "auto" }} containerRef={scrollContainerRef} />}
@@ -76,10 +71,7 @@ function OneTechMeetTheCoachesSection({ toggleModal, sectionId, coaches, data, r
           style={{
             flexWrap: "nowrap",
             overflowX: "scroll",
-            // justifyContent: "center",
-            // scrollBehavior: "smooth",
           }}
-          // onScroll={(e) => handleScroll(e.target.scrollLeft)}
         >
           {coaches?.map((coach, index) => {
             return (
@@ -90,11 +82,8 @@ function OneTechMeetTheCoachesSection({ toggleModal, sectionId, coaches, data, r
           })}
         </Row>
 
-        <div
-          // style={{ textTransform: "justify", marginTop: 20 }}
-          className="coaches-description"
-        >
-          <p dangerouslySetInnerHTML={{ __html: description }}></p>
+        <div className="coaches-description">
+          <p className="body-font" dangerouslySetInnerHTML={{ __html: description }}></p>
           <div
             style={{
               display: "flex",
@@ -104,7 +93,7 @@ function OneTechMeetTheCoachesSection({ toggleModal, sectionId, coaches, data, r
             }}
           >
             <Button
-              className="touchable-opacity elevate-2 mt-5"
+              className="touchable-opacity elevate-2 mt-5 small-font"
               style={{
                 borderRadius: 55,
                 padding: "15px 40px",

--- a/src/user-portal/pages/technology/TakeActionSection.js
+++ b/src/user-portal/pages/technology/TakeActionSection.js
@@ -30,8 +30,6 @@ const dummies = [
     url: "vendors",
     type: "vendors",
   },
-
- 
 ];
 function TakeAtionSetion({ sectionId, scrollToSection, authUser, trackActivity, campaign, vendors }) {
   const navigator = useNavigate();
@@ -81,18 +79,19 @@ function TakeAtionSetion({ sectionId, scrollToSection, authUser, trackActivity, 
               >
                 <i className={`fa ${item.icon} mb-1 mt-2`} style={{ fontSize: 60, color: "var(--app-accent-3)" }} />
                 <h6
-                  className="mt-2 mb-2"
+                  className="mt-2 mb-2 body-font"
                   style={{
                     color: "var(--app-accent-3)",
                     textTransform: "uppercase",
                     textAlign: "center",
-                    fontSize: 13,
-                    fontWeight:"bold"
+                    // fontSize: 13,
+                    fontWeight: "bold",
                   }}
                 >
                   {item.title}
                 </h6>
                 <p
+                  className="body-font"
                   style={{
                     // fontSize: "medium",
                     textAlign: "center",
@@ -120,7 +119,9 @@ function TakeAtionSetion({ sectionId, scrollToSection, authUser, trackActivity, 
                     borderRadius: 500,
                   }}
                 >
-                  <p style={{ margin: 0, fontSize: 13, fontWeight: "bold" }}>{item.actionText}</p>
+                  <p className="small-font" style={{ margin: 0, fontWeight: "bold" }}>
+                    {item.actionText}
+                  </p>
                 </div>
               </Col>
             );

--- a/src/user-portal/pages/technology/TechnologyFullViewPage.js
+++ b/src/user-portal/pages/technology/TechnologyFullViewPage.js
@@ -40,6 +40,7 @@ import OneTechEventSection from "./OneTechEventSection";
 import { useMediaQuery } from "react-responsive";
 import CampaignNotLive from "../landing-page/CampaignNotLive";
 import SmartRichText from "../../../components/SmartRichText";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 const DEFAULT_READ_HEIGHT = 190;
 const PREVIEW_TEXT_LENGHT = 1000;
@@ -301,14 +302,8 @@ function TechnologyFullViewPage({
       <div style={{ marginTop: 100 }} className="one-tech-wrapper">
         <OptimumWrapper>
           <CampaignNotLive />
-          <h2
-            style={{
-              color: "var(--app-accent-3)",
-              fontSize: "var(--mob-title-font-size)",
-            }}
-          >
-            {name || "..."}
-          </h2>
+          <SectionTitle>{name || "..."}</SectionTitle>
+
           <Row>
             <Col lg={9} className="one-tech-main">
               {image?.url && <img className="elevate-float-pro mt-2" src={image?.url || carPhoto} alt={"event"} />}

--- a/src/user-portal/pages/technology/TechnologyFullViewPage.js
+++ b/src/user-portal/pages/technology/TechnologyFullViewPage.js
@@ -288,13 +288,8 @@ function TechnologyFullViewPage({
       .catch((e) => console.log("COMMENT_DELETION_ERROR_SYNT: ", e?.toString()));
   };
 
-  // const READ_HEIGHT = isMobile ? 100 : DEFAULT_READ_HEIGHT;
   const READ_HEIGHT = DEFAULT_READ_HEIGHT;
   const LENGTH = isMobile ? MOBILE_PREVIEW_TEXT_LENGTH : PREVIEW_TEXT_LENGHT;
-
-  // const { truncatedContent, isLong } = truncateRichText(description, READ_HEIGHT);
-  // console.log("IS REALLY LONG", isLong);
-  // const isReallyLong = description.length > LENGTH; // This is not a good way of checking, change it later
 
   return (
     <div>
@@ -317,7 +312,7 @@ function TechnologyFullViewPage({
                 comments={comments?.length || 0}
               />
 
-              <SmartRichText>{description}</SmartRichText>
+              <SmartRichText className="body-font">{description}</SmartRichText>
             </Col>
             <Col lg={3}>
               <div
@@ -340,12 +335,13 @@ function TechnologyFullViewPage({
                   }}
                 >
                   <p
+                    className="small-font"
                     style={{
                       alignSelf: "center",
                       justifySelf: "center",
                       textAlign: "center",
                       margin: 0,
-                      fontSize: 13,
+                      // fontSize: 13,
                       fontWeight: "bold",
                       width: "83%",
                     }}
@@ -383,18 +379,16 @@ function TechnologyFullViewPage({
                   style={{
                     background: "black",
                     padding: "10px 20px",
-
-                    // borderBottomRightRadius: 5,
                     marginTop: "auto",
                   }}
                 >
                   <p
+                    className="body-font"
                     style={{
                       color: "white",
                       margin: 0,
-                      //   padding: "7px 30px",
                       textAlign: "center",
-                      fontSize: 16,
+                      // fontSize: 16,
                       fontWeight: "bold",
                     }}
                   >
@@ -414,7 +408,7 @@ function TechnologyFullViewPage({
                     alignItems: "center",
                   }}
                 >
-                  <p style={{ margin: 0 }}>
+                  <p className="body-font" style={{ margin: 0 }}>
                     <i
                       className="fa fa-comment"
                       style={{
@@ -433,7 +427,9 @@ function TechnologyFullViewPage({
                   </p>
                 </div>
                 <div className="mt-2">
-                  <small style={{ color: "" }}>This is what people think</small>
+                  <small className="small-font" style={{ color: "" }}>
+                    This is what people think
+                  </small>
                   <div className="mt-2">
                     {comments?.slice(0, 3)?.map((com, index) => {
                       const isForCurrentUser = commentIsForUser(com, authUser);
@@ -451,16 +447,17 @@ function TechnologyFullViewPage({
                           key={com?.id}
                         >
                           <h6
+                            className="small-font"
                             style={{
                               // textDecoration: "underline",
-                              fontSize: 14,
+                              // fontSize: 14,
                               fontWeight: "bold",
                               color: !isForCurrentUser ? "var(--app-main-color)" : "var(--app-accent-3)",
                             }}
                           >
                             {user?.full_name || "..."} {isForCurrentUser ? " (Yours)" : ""}
                           </h6>
-                          <small>
+                          <small className="small-font">
                             {message.substr(0, COMMENT_LENGTH)}
                             {message.length > COMMENT_LENGTH ? (
                               <span
@@ -517,6 +514,7 @@ function TechnologyFullViewPage({
                   onClick={() => triggerCommentBox(authUser)}
                 >
                   <p
+                    className="body-font"
                     style={{
                       margin: 0,
                       color: "var(--app-main-color)",
@@ -528,7 +526,7 @@ function TechnologyFullViewPage({
                   </p>
                 </div>
                 <div
-                  className="touchable-opacity mt-2"
+                  className="touchable-opacity mt-2 body-font"
                   style={{
                     background: "var(--app-main-color)",
                     display: "flex",

--- a/src/user-portal/pages/technology/Vendors.js
+++ b/src/user-portal/pages/technology/Vendors.js
@@ -16,8 +16,6 @@ function Vendors({ sectionId, data, vendors }) {
       style={{
         background: "var(--app-accent-1)",
         width: "100%",
-        // padding: "80px 0px",
-        // minHeight: 200,
       }}
     >
       <OptimumWrapper>
@@ -27,7 +25,7 @@ function Vendors({ sectionId, data, vendors }) {
         <p
           dangerouslySetInnerHTML={{ __html: description }}
           style={{ textAlign: "justify" }}
-          className="mb-4 paragraph-font"
+          className="mb-4 body-font"
         ></p>
 
         <Row>
@@ -42,7 +40,7 @@ function Vendors({ sectionId, data, vendors }) {
                     if (!link) return;
                     window.open(link, "_blank");
                   }}
-                  className="touchable-opacity paragraph-font"
+                  className="touchable-opacity body-font"
                   key={vendor?.id?.toString()}
                 >
                   {vendor?.name || "..."}

--- a/src/user-portal/pages/technology/WhySection.js
+++ b/src/user-portal/pages/technology/WhySection.js
@@ -39,8 +39,6 @@ function WhySection({ sectionId, overview, campaignName, overview_title }) {
       style={{
         background: "white",
         width: "100%",
-        // padding: "80px 0px",
-        // minHeight: 200,
       }}
     >
       <OptimumWrapper>

--- a/src/user-portal/pages/technology/WhySection.js
+++ b/src/user-portal/pages/technology/WhySection.js
@@ -63,7 +63,7 @@ function WhySection({ sectionId, overview, campaignName, overview_title }) {
               >
                 <img src={image?.url} style={{ height: 70, width: 70, objectFit: "contain" }} alt={image?.name} />
                 <h6
-                  className="mt-3 mb-3"
+                  className="mt-3 mb-3 subheader-font"
                   style={{
                     color: "var(--app-accent-3)",
                     textTransform: "uppercase",
@@ -73,6 +73,7 @@ function WhySection({ sectionId, overview, campaignName, overview_title }) {
                   {title || {}}
                 </h6>
                 <p
+                  className="body-font"
                   dangerouslySetInnerHTML={{ __html: description }}
                   style={{ textAlign: "justify", lineHeight: "1.5" }}
                 ></p>

--- a/src/user-portal/pages/testimonials/NewTestimonialForm.js
+++ b/src/user-portal/pages/testimonials/NewTestimonialForm.js
@@ -129,7 +129,7 @@ function NewTestimonialForm({ close, campaign, callbackOnSubmit, authUser, updat
             }}
           />
         </InputGroup> */}
-        <InputGroup className="mb-3 mt-2">
+        <InputGroup className="mb-3 mt-2 body-font">
           <InputGroup.Text style={{ fontWeight: "bold" }} id="basic-addon1">
             Title*
           </InputGroup.Text>

--- a/src/user-portal/pages/testimonials/OneTestimonial.js
+++ b/src/user-portal/pages/testimonials/OneTestimonial.js
@@ -123,14 +123,14 @@ function OneTestimonial({ testimonials, updateTestimonials, campaign, init, togg
       <SectionTitle>{title || "..."}</SectionTitle>
       <Row>
         <Col lg={9}>
-          <p className="mt-4" style={{ textAlign: "justify" }}>
+          <p className="mt-4 body-font" style={{ textAlign: "justify" }}>
             <span dangerouslySetInnerHTML={{ __html: body }} style={{ display: "block", overflowY: "hidden" }}></span>
           </p>
 
           <p
             role="button"
             onClick={() => initiateTestimonialCreation(authUser)}
-            className="touchable-opacity"
+            className="touchable-opacity body-font"
             style={{
               textDecoration: "underline",
               fontWeight: "bold",
@@ -180,6 +180,7 @@ function OneTestimonial({ testimonials, updateTestimonials, campaign, init, togg
               }}
             >
               <h6
+                className="body-font"
                 style={{
                   color: "white",
                   fontWeight: "bold",
@@ -211,7 +212,7 @@ function OneTestimonial({ testimonials, updateTestimonials, campaign, init, togg
                     tabIndex={0}
                     key={index?.toString()}
                     onClick={() => navigator(`/campaign/${item?.campaign?.id}/technology/testimonial/${item?.id}`)}
-                    className="touchable-opacity"
+                    className="touchable-opacity small-font"
                     style={{
                       color: "var(--app-main-color)",
                       fontWeight: "bold",
@@ -235,7 +236,7 @@ function OneTestimonial({ testimonials, updateTestimonials, campaign, init, togg
           )}
           <div
             onClick={() => initiateTestimonialCreation(authUser)}
-            className="mt-2 touchable-opacity"
+            className="mt-2 touchable-opacity body-font"
             style={{
               background: "var(--app-main-color)",
               padding: 10,

--- a/src/user-portal/pages/testimonials/TestimonialBox.js
+++ b/src/user-portal/pages/testimonials/TestimonialBox.js
@@ -18,9 +18,10 @@ function TestimonialBox({ title, user, image, body, campaign_technology, campaig
 
   return (
     <div className="testi-container flex-column">
-      <h5 style={{ fontSize: "1.07rem" }}>{title || "..."}</h5>
-      <h6 style={{ fontSize: 15, color: "var(--app-main-color)" }}>
-      
+      <h5 className="small-font" style={{ fontWeight: "bold", color: "var(--app-main-color)" }}>
+        {title || "..."}
+      </h5>
+      <h6 className="small-font text-muted" style={{}}>
         {userName ? `${userName} ${comName ? "from" : ""} ${comName || ""}` : "..."}
       </h6>
       <div
@@ -32,7 +33,7 @@ function TestimonialBox({ title, user, image, body, campaign_technology, campaig
         }}
         dangerouslySetInnerHTML={{ __html: preview }}
       ></div>
-     
+
       <div
         style={{
           display: "flex",
@@ -61,10 +62,10 @@ function TestimonialBox({ title, user, image, body, campaign_technology, campaig
         <p
           role={"button"}
           tabIndex={0}
-          className="touchable-opacity"
+          className="touchable-opacity small-font"
           onClick={() => navigator(route)}
           style={{
-            fontSize: 15,
+            // fontSize: 15,
             marginLeft: "auto",
             fontWeight: "bold",
             color: "var(--app-main-color)",

--- a/src/user-portal/pages/testimonials/TestimonialSection.js
+++ b/src/user-portal/pages/testimonials/TestimonialSection.js
@@ -9,16 +9,7 @@ import Filter from "../../../components/Filter";
 function TestimonialSection({ sectionId, technologies, defaultTab, campaign }) {
   const navigator = useNavigate();
   const testimonialsOfEachTech = technologies?.map(
-    ({
-      campaign_technology,
-      testimonials,
-      is_icon,
-      is_image,
-      image,
-      icon,
-      name,
-      id,
-    }) => ({
+    ({ campaign_technology, testimonials, is_icon, is_image, image, icon, name, id }) => ({
       id,
       campaign_technology,
       testimonials,
@@ -87,10 +78,7 @@ function TestimonialSection({ sectionId, technologies, defaultTab, campaign }) {
             <AddNewTestimonial onClick={() => navigator(testimonialRoute)} />
           </div>
 
-          <CustomTabView
-            defaultTab={defaultTab || firstOne?.id}
-            data={intoTabs}
-          ></CustomTabView>
+          <CustomTabView defaultTab={defaultTab || firstOne?.id} data={intoTabs}></CustomTabView>
         </Container>
       </CenteredWrapper>
     </div>
@@ -111,7 +99,7 @@ export const AddNewTestimonial = ({ style, onClick, text, icon }) => {
           e.preventDefault();
           onClick && onClick();
         }}
-        className="touchable-opacity link-text"
+        className="touchable-opacity link-text body-font"
         style={{
           color: "var(--app-accent-3)",
           fontWeight: "bold",
@@ -119,10 +107,7 @@ export const AddNewTestimonial = ({ style, onClick, text, icon }) => {
           ...(style || {}),
         }}
       >
-        <i
-          className={`fa fa-${icon || "plus"}`}
-          style={{ marginRight: 10, fontWeight: "bold" }}
-        />
+        <i className={`fa fa-${icon || "plus"}`} style={{ marginRight: 10, fontWeight: "bold" }} />
         {text || "Add your own testimonial here"}
         {/* <i
           className="fa fa-long-arrow-right"

--- a/src/user-portal/pages/testimonials/TestimonialSectionWithFilters.js
+++ b/src/user-portal/pages/testimonials/TestimonialSectionWithFilters.js
@@ -10,29 +10,15 @@ import { fetchUrlParams, mergeArrays } from "../../../utils/utils";
 import { ArrowButtons } from "../../../components/pieces/ArrowButtons";
 import OurParagraph from "../../../components/OurParagraph";
 import NewTestimonialForm from "./NewTestimonialForm";
+import SectionTitle from "../../../components/pieces/SectionTitle";
 
 export const TESTIMONIAL_FORM_SHOW_KEY = "testimonial-form";
-function TestimonialSectionWithFilters({
-  sectionId,
-  technologies,
-  defaultTab,
-  campaign,
-  protectedFunction,
-}) {
+function TestimonialSectionWithFilters({ sectionId, technologies, defaultTab, campaign, protectedFunction }) {
   const [showForm, setShowForm] = useState(false);
   const containerRef = useRef();
   const navigator = useNavigate();
   const testimonialsOfEachTech = technologies?.map(
-    ({
-      campaign_technology,
-      testimonials,
-      is_icon,
-      is_image,
-      image,
-      icon,
-      name,
-      id,
-    }) => ({
+    ({ campaign_technology, testimonials, is_icon, is_image, image, icon, name, id }) => ({
       id,
       campaign_technology,
       testimonials,
@@ -112,7 +98,9 @@ function TestimonialSectionWithFilters({
         <Container>
           <div className="row-flex t-with-filter-top">
             <div>
-              <h2
+              <SectionTitle>Testimonials</SectionTitle>
+              {/* <h2
+                className="header-font"
                 style={{
                   color: "var(--app-accent-3)",
                   fontWeight: "bold",
@@ -120,12 +108,10 @@ function TestimonialSectionWithFilters({
                 }}
               >
                 Testimonials
-              </h2>
+              </h2> */}
               <AddNewTestimonial
                 icon={showForm ? "minus" : "plus"}
-                text={
-                  showForm ? "Hide testimonial form" : "Add your testimonial here"
-                }
+                text={showForm ? "Hide testimonial form" : "Add your testimonial here"}
                 onClick={() => {
                   addTestimonial();
                 }}
@@ -133,10 +119,7 @@ function TestimonialSectionWithFilters({
             </div>
 
             {!noTestimonials && !showForm && (
-              <ArrowButtons
-                containerRef={containerRef}
-                style={{ marginLeft: "auto" }}
-              />
+              <ArrowButtons containerRef={containerRef} style={{ marginLeft: "auto" }} />
             )}
           </div>
 
@@ -145,8 +128,7 @@ function TestimonialSectionWithFilters({
           {!showForm && !noTestimonials && (
             <>
               <OurParagraph>
-                Scroll from left to right to see more testimonials, or use the arrow
-                buttons(top right) to scroll
+                Scroll from left to right to see more testimonials, or use the arrow buttons(top right) to scroll
               </OurParagraph>
               <Filter
                 title="Filter testimonials by"

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -12,8 +12,8 @@ export function formatTimeRange(startDateString, endDateString) {
 
     return `${formattedStartDate} ${formattedStartTime} - ${formattedEndTime}`;
   } else {
-    const formattedStartDate = format(startDate, "do MMMM yyyy");
-    const formattedEndDate = format(endDate, "do MMMM yyyy");
+    const formattedStartDate = format(startDate, "do MMM, yyyy");
+    const formattedEndDate = format(endDate, "do MMM, yyyy");
 
     return `${formattedStartDate} - ${formattedEndDate}`;
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [x] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

- [X] Increased font size for everything! I defined 4 font sizes. (Title, header, body, and small). All defined in universal.css. So now all the important aspects of the site use one of these fonts. Everything is much bigger now (I dont like it), but hopefully the target users do 🤣 🤣 . And in the scenario that they dont like it, it should be much easier to make changes now. 
- [X] Also fixed a bug in "Get help" section. Selecting different communities in the modal was meant to update the state to the selected community then in turn take you to the "help" link of your selected community. There was a bug in that which forced the user's first choice in the modal to persist. Meaning, if you opened the dialog and chose "Wayland" then clicked "Lets Go", you would be able to Go to the "help_link" of Wayland appropriately. But switching to "Acton" afterward would not take you to the "help_link" of Acton; it would still take you to Wayland's "help_link".... Unless you closed the modal, reopened, then chose "Acton"..... I think thats what Aimee has been drawing our attention to. 
Its fixed in this PR. 

