### PR TITLE
refactor: Refactor WhySection rendering in technology page

### DIFF
--- a/src/user-portal/pages/technology/WhySection.js
+++ b/src/user-portal/pages/technology/WhySection.js
@@ -43,7 +43,7 @@ function WhySection({ sectionId, overview, campaignName, overview_title }) {
     >
       <OptimumWrapper>
         {/* <SectionTitle className="mb-5">{overview_title || `Why ${campaignName}?`}</SectionTitle> BRING IT BACK WHEN THERE IS AN ADMIN SECTION TO FIX IT */}
-        <SectionTitle className="mb-5">{`Why ${campaignName}?`}</SectionTitle>
+        <SectionTitle className="mb-3">{`Why ${campaignName}?`}</SectionTitle>
 
         <Row>
           {(overview || []).map((item, index) => {

--- a/src/user-portal/pages/technology/WhySection.js
+++ b/src/user-portal/pages/technology/WhySection.js
@@ -49,34 +49,25 @@ function WhySection({ sectionId, overview, campaignName, overview_title }) {
           {(overview || []).map((item, index) => {
             const { image, title, description } = item || {};
             return (
-              <Col
-                className="overview-item"
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  // justifyContent: "center",
-                }}
-                key={index?.toString()}
-                lg={6}
-                gap={3}
-              >
-                <img src={image?.url} style={{ height: 70, width: 70, objectFit: "contain" }} alt={image?.name} />
-                <h6
-                  className="mt-3 mb-3 subheader-font"
-                  style={{
-                    color: "var(--app-accent-3)",
-                    textTransform: "uppercase",
-                    fontWeight: "bold",
-                  }}
-                >
-                  {title || {}}
-                </h6>
-                <p
-                  className="body-font"
-                  dangerouslySetInnerHTML={{ __html: description }}
-                  style={{ textAlign: "justify", lineHeight: "1.5" }}
-                ></p>
+              <Col lg={6} className="overview-item d-flex align-items-center justify-content-center mb-4" key={index?.toString()}>
+                <div className={"w-100 p-3 border h-100 rounded-4"}>
+                  <img src={image?.url || "/img/fallback-img.png"} className={"w-100 rounded-2"} style={{ objectFit: "cover", minHeight : 150, maxHeight : 220 }} alt={image?.name}/>
+                  <h6
+                    className="mt-3 mb-2 subheader-font"
+                    style={{
+                      color: "var(--app-accent-3)",
+                      textTransform: "capitalize",
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {title || {}}
+                  </h6>
+                  <div
+                    className="body-font lh-sm"
+                    dangerouslySetInnerHTML={{ __html: description }}
+                    style={{ textAlign: "justify", }}
+                  ></div>
+                </div>
               </Col>
             );
           })}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
This PR puts the disorderly arrangement of the content of the Why technology section into order by clamping the content into cards with better looking image alignments and reduces the margin beneath the header.