### PR TITLE
revert: Uncomment logo display in navigation bar

### DIFF
--- a/src/components/navbar/AppNavigationBar.js
+++ b/src/components/navbar/AppNavigationBar.js
@@ -20,8 +20,8 @@ function AppNavigationBar({ menu, campaign }) {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="me-auto mx-auto" style={{ alignItems: "center" }}>
-            {/* <Nav.Link> */}
-            {/* {primary_logo?.url && (
+             <Nav.Link>
+             {primary_logo?.url && (
               <img
                 src={primary_logo?.url}
                 style={{
@@ -32,8 +32,8 @@ function AppNavigationBar({ menu, campaign }) {
                 }}
                 alt={"logo"}
               />
-            )} */}
-            {/* </Nav.Link> */}
+            )}
+             </Nav.Link>
             {menu?.map((menu) => {
               const excluded = EXCLUDE_FROM_NAV.includes(menu?.key?.toLowerCase());
               if (excluded) return <></>;
@@ -93,7 +93,7 @@ function AppNavigationBar({ menu, campaign }) {
               );
             })}
 
-            {/* {secondary_logo?.url && (
+             {secondary_logo?.url && (
               <img
                 src={secondary_logo?.url}
                 style={{
@@ -104,7 +104,7 @@ function AppNavigationBar({ menu, campaign }) {
                 }}
                 alt={"logo"}
               />
-            )} */}
+            )}
           </Nav>
         </Navbar.Collapse>
       </Container>

--- a/src/user-portal/pages/getting-started/NewOneBox.js
+++ b/src/user-portal/pages/getting-started/NewOneBox.js
@@ -27,7 +27,7 @@ function NewOneBox({
   };
 
   return (
-    <div className="card rounded-4 one-box-container">
+    <div className="card rounded-4 one-box-container h-100">
       <div className="card-body p-0 new-one-box">
         {image && <img src={image?.url} alt={image?.name} className={" rounded-top-4"} />}
         <div className="new-one-box-body p-3">
@@ -56,7 +56,7 @@ function NewOneBox({
       </div>
 
       <div className="card-footer border-0 bg-transparent p-3">
-        <Row className={"justify-content-end d-none d-md-flex"}>
+        <Row className={"justify-content-center d-none d-md-flex"}>
           <Col sm={"auto"}>
             <Button
               onClick={() => {

--- a/src/user-portal/pages/landing-page/LandingPage.js
+++ b/src/user-portal/pages/landing-page/LandingPage.js
@@ -103,6 +103,7 @@ function LandingPage({
     if (community) updateUserInRedux(json);
     close && close();
   };
+
   const tellUsWhereYouAreFrom = (justLoadedCampaign) => {
     const user = authUser || localStorage.getItem(USER_STORAGE_KEY);
     const firstTime = !user || user === "null";


### PR DESCRIPTION
The navigation bar now displays the primary and secondary logos that were previously commented out, improving site branding and user experience. Also, applied minor style adjustment to the component in the GettingStartedSection, ensuring full container height for more consistent visuals.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
