### PR TITLE
fix: Remove padding from Navbar links

### DIFF
--- a/src/components/navbar/AppNavigationBar.js
+++ b/src/components/navbar/AppNavigationBar.js
@@ -65,7 +65,7 @@ function AppNavigationBar({ menu, campaign }) {
                     if (excluded) return <></>;
                     if (!menu?.children)
                       return (
-                        <Col sm={12} md={"auto"} key={i} className={"d-flex  align-items-center"}>
+                        <Col sm={12} md={"auto"} key={i} className={"d-flex  align-items-center px-0"}>
                           <Nav.Link
                             className="c-nav-item body-font d-flex mx-md-2 mx-auto"
                             key={menu?.key}
@@ -87,7 +87,7 @@ function AppNavigationBar({ menu, campaign }) {
                         </Col>
                       );
                     return (
-                      <Col key={i} sm={12} md={"auto"} className={"d-flex align-items-center"}>
+                      <Col key={i} sm={12} md={"auto"} className={"d-flex align-items-center px-0"}>
                         <NavDropdown
                           className={"fw-bold text-capitalize mx-md-2 mx-auto body-font d-flex"}
                           title={


### PR DESCRIPTION
Padding has been removed from links in the Navbar layout component. This css change will maintain consistent spacing between elements across various screen sizes, thereby improving the layout's visual alignment and overall responsive design.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
Fixes poor alignment of navbar sections items due to extra padding around nav items