### PR TITLE
fix: Refine navbar padding

### DIFF
--- a/src/components/navbar/AppNavigationBar.js
+++ b/src/components/navbar/AppNavigationBar.js
@@ -67,7 +67,7 @@ function AppNavigationBar({ menu, campaign }) {
                       return (
                         <Col sm={12} md={"auto"} key={i} className={"d-flex  align-items-center px-0"}>
                           <Nav.Link
-                            className="c-nav-item body-font d-flex mx-md-2 mx-auto"
+                            className="c-nav-item body-font d-flex mx-md-2 mx-auto px-0"
                             key={menu?.key}
                             style={{
                               textTransform: "capitalize",
@@ -89,7 +89,7 @@ function AppNavigationBar({ menu, campaign }) {
                     return (
                       <Col key={i} sm={12} md={"auto"} className={"d-flex align-items-center px-0"}>
                         <NavDropdown
-                          className={"fw-bold text-capitalize mx-md-2 mx-auto body-font d-flex"}
+                          className={"fw-bold text-capitalize mx-md-2 mx-auto body-font d-flex px-0"}
                           title={
                             <span className="c-nav-item my-auto d-inline-block">
                           <i className={`fa ${menu.icon}`} style={{ marginRight: 6 }}></i>


### PR DESCRIPTION
Removed excess padding from Nav.Link and NavDropdown components in AppNavigationBar.js. This alteration is intended to tidy up the visual interface of the navigation bar components.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
