### PR TITLE
fix: adjust navbar dropdown margin for better alignment

### DIFF
--- a/src/components/navbar/AppNavigationBar.js
+++ b/src/components/navbar/AppNavigationBar.js
@@ -89,7 +89,7 @@ function AppNavigationBar({ menu, campaign }) {
                     return (
                       <Col key={i} sm={12} md={"auto"} className={"d-flex align-items-center px-0"}>
                         <NavDropdown
-                          className={"fw-bold text-capitalize mx-md-2 mx-auto body-font d-flex px-0"}
+                          className={"fw-bold text-capitalize mx-md-1 mx-auto body-font d-flex px-0"}
                           title={
                             <span className="c-nav-item my-auto d-inline-block">
                           <i className={`fa ${menu.icon}`} style={{ marginRight: 6 }}></i>


### PR DESCRIPTION
The margin of the navbar dropdown component was slightly adjusted. The revision enhances the alignment and improves the visual sequence when viewed in a medium-sized device. This makes the user interface more aesthetic and easy to navigate.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
