### PR TITLE
refactor: Add event type and refactor date/time display on events pages

### DIFF
--- a/src/user-portal/pages/events/EventBox.js
+++ b/src/user-portal/pages/events/EventBox.js
@@ -6,7 +6,8 @@ import { Col, Row } from "react-bootstrap";
 function EventBox({ event, campaign_technology }) {
   const { campaign } = campaign_technology || {};
 
-  const { name, image, start_date, end_date, id } = event || {};
+  const { name, image, start_date, end_date, event_type, id } = event || {};
+  console.log(event)
   const navigator = useNavigate();
 
   function gotoEvent() {
@@ -41,15 +42,22 @@ function EventBox({ event, campaign_technology }) {
       <div className="card-footer border-0 bg-transparent p-0">
         <Row>
           <Col className={"pe-0"}>
-            <p className="text-sm fw-medium text-accent-3">
+            <p className="text-sm fw-medium text-accent-3 mb-0">
               <span>{formatDate(start_date)}</span>
-              <span className={"text-dark"}> &mdash; </span>
-              <span>{formatDate(end_date)}</span>
+              {/*<span className={"text-dark"}> &mdash; </span>
+              <span>{formatDate(end_date)}</span>*/}
             </p>
           </Col>
           <Col sm={"auto ps-0"}>
-            <p className="text-sm fw-medium text-accent-3">
-              <span className={"text-muted"}>{formatTime(start_date)}</span>
+            <p className="text-sm fw-medium text-accent-3 mb-0">
+              <span className={"text-muted"}>{formatTime(start_date, "K:mm aa")}</span>
+            </p>
+          </Col>
+        </Row>
+        <Row>
+          <Col className={"pe-0"}>
+            <p className="text-sm fw-medium text-accent mb-0">
+              <span>{event_type}</span>
             </p>
           </Col>
         </Row>

--- a/src/user-portal/pages/events/OneEvent.js
+++ b/src/user-portal/pages/events/OneEvent.js
@@ -10,7 +10,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { apiCall } from "../../../api/messenger";
 import { appInnitAction, updateEventsObj } from "../../../redux/actions/actions";
-import { formatTimeRange, setPageTitle } from "../../../utils/utils";
+import { formatDate, formatTimeRange, setPageTitle } from "../../../utils/utils";
 
 function OneEvent({ events, updateEvents, init, campaign }) {
   const [event, setEvent] = useState(LOADING);
@@ -19,7 +19,6 @@ function OneEvent({ events, updateEvents, init, campaign }) {
   const id = eventId;
 
   const { name, start_date_and_time, description, end_date_and_time, image, external_link } = event || {};
-
   const campaignExists = campaign && campaign !== LOADING;
 
   useEffect(() => {
@@ -51,17 +50,16 @@ function OneEvent({ events, updateEvents, init, campaign }) {
 
   return (
     <PageWrapper>
-      <SectionTitle>{name || "..."}</SectionTitle>
+      <SectionTitle className={"text-large"}>{name || "..."}</SectionTitle>
       <Row>
         <Col lg={9}>
           <img
-            className="mt-3"
+            className="mt-3 rounded-4"
             src={image?.url}
             style={{
               width: "100%",
               height: 420,
               objectFit: "cover",
-              borderRadius: 10,
             }}
             alt={"event"}
           />
@@ -78,9 +76,15 @@ function OneEvent({ events, updateEvents, init, campaign }) {
             <h6 className="body-font text-muted" style={{ fontWeight: "" }}>
               Date
             </h6>
-            <small className="small-font" style={{ fontWeight: "bold" }}>
+            {/*<small className="small-font" style={{ fontWeight: "bold" }}>
               {formatTimeRange(start_date_and_time, end_date_and_time)}
-            </small>
+            </small>*/}
+
+            <p className="text-sm fw-medium text-accent-3">
+              <span>{formatDate(start_date_and_time)}</span>
+              {/*<span className={"text-dark"}> &mdash; </span>
+              <span>{formatDate(end_date_and_time)}</span>*/}
+            </p>
           </div>
 
           {external_link && (


### PR DESCRIPTION
In this commit, the event type has been added to the event's display box. Date and time formatting has been altered to achieve improved user readability. In addition, image presentation and section titles on the individual event page have been redesigned for a more visually appealing and informative layout, clearing off redundant codes and comments.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [x] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
This PR updates the formatting of the dates on events cards and event pages as required by the:

Related tickets
[#246](https://github.com/massenergize/massenergize-campaigns/issues/246)

Additionally the event type (i.e. whether In Person or Online) has now been added to the event card and event page.
<img width="1511" alt="Screenshot 2024-02-23 at 7 39 31 AM" src="https://github.com/massenergize/massenergize-campaigns/assets/26628335/b65eba72-9f04-4a13-989c-7b1b4c551876">
<img width="1417" alt="Screenshot 2024-02-23 at 7 30 26 AM" src="https://github.com/massenergize/massenergize-campaigns/assets/26628335/faeb4c65-c5f7-495a-8b0f-567e4eee11ee">
