### PR TITLE
Feat: restructure event items on one event page  & event box

### DIFF
--- a/src/user-portal/pages/events/EventBox.js
+++ b/src/user-portal/pages/events/EventBox.js
@@ -6,7 +6,6 @@ import { Col, Row } from "react-bootstrap";
 function EventBox({ event, campaign_technology }) {
   const { campaign } = campaign_technology || {};
 
-
   const { name, image, start_date, end_date, id, event_type } = event || {};
   const navigator = useNavigate();
 
@@ -52,6 +51,13 @@ function EventBox({ event, campaign_technology }) {
       <div className="card-footer border-0 bg-transparent p-0">
         <Row>
           <Col className={"pe-0"}>
+            <p className="text-sm fw-medium text-accent mb-0">
+              <span>{event_type}</span>
+            </p>
+          </Col>
+        </Row>
+        <Row>
+          <Col className={"pe-0"}>
             <p className="text-sm fw-medium text-accent-3 mb-0">
               <span>{formatDate(start_date)}</span>
               {/*<span className={"text-dark"}> &mdash; </span>
@@ -61,13 +67,6 @@ function EventBox({ event, campaign_technology }) {
           <Col sm={"auto ps-0"}>
             <p className="text-sm fw-medium text-accent-3 mb-0">
               <span className={"text-muted"}>{formatTime(start_date, "K:mm aa")}</span>
-            </p>
-          </Col>
-        </Row>
-        <Row>
-          <Col className={"pe-0"}>
-            <p className="text-sm fw-medium text-accent mb-0">
-              <span>{event_type}</span>
             </p>
           </Col>
         </Row>

--- a/src/user-portal/pages/events/OneEvent.js
+++ b/src/user-portal/pages/events/OneEvent.js
@@ -52,46 +52,34 @@ function OneEvent({ events, updateEvents, init, campaign }) {
     <PageWrapper>
       <SectionTitle className={"text-large"}>{name || "..."}</SectionTitle>
       <Row>
-        <Col lg={9}>
-            <img
-              className="mt-3"
-              src={image?.url || "/img/fallback-img.png"}
-              style={{
-                width: "100%",
-                ...(image?.url ? {minHeight: 420,} : { height: 420, }),
-                objectFit: "cover",
-                borderRadius: 10,
-              }}
-              alt={"event"}
-            />
-          <p className="mt-4 body-font" style={{ textAlign: "justify" }}>
-            <span
-              dangerouslySetInnerHTML={{ __html: description }}
-              style={{ display: "block", overflowY: "hidden" }}
-            ></span>
-          </p>
-        </Col>
-        <Col lg={3} className="mt-2">
+        <Col lg={4} className="mt-2">
+          <img
+            className="mt-3"
+            src={image?.url || "/img/fallback-img.png"}
+            style={{
+              width: "100%",
+              height:200,
+              // ...(image?.url ? { minHeight: 200 } : { height: 200 }),
+              objectFit: "cover",
+              borderRadius: 10,
+              marginBottom: 10,
+            }}
+            alt={"event"}
+          />
           <div>
-            <h6 className="body-font text-muted" style={{ fontWeight: "" }}>
-              Date
+            <h6 className="body-font" style={{ fontWeight: "", color: "black" }}>
+              <span>Date</span>
+              {event?.event_type && (
+                // <div style={{ marginTop: 10 }}>
+                <small style={{ marginLeft: 5 }}>({event?.event_type})</small>
+                // </div>
+              )}
             </h6>
-            {/*<small className="small-font" style={{ fontWeight: "bold" }}>
-              {formatTimeRange(start_date_and_time, end_date_and_time)}
-            </small>*/}
 
             <p className="text-sm fw-medium text-accent-3">
               <span>{formatDate(start_date_and_time)}</span>
-              {/*<span className={"text-dark"}> &mdash; </span>
-              <span>{formatDate(end_date_and_time)}</span>*/}
             </p>
           </div>
-
-          {event?.event_type && (
-            <div style={{ marginTop: 10 }}>
-              <p style={{ color: "var(--app-accent-3)" }}>{event?.event_type}</p>
-            </div>
-          )}
 
           {external_link && (
             <div
@@ -111,6 +99,14 @@ function OneEvent({ events, updateEvents, init, campaign }) {
               <p style={{ margin: 0 }}>Register / Join</p>
             </div>
           )}
+        </Col>
+        <Col lg={8}>
+          <p className="mt-4 body-font" style={{ textAlign: "justify" }}>
+            <span
+              dangerouslySetInnerHTML={{ __html: description }}
+              style={{ display: "block", overflowY: "hidden" }}
+            ></span>
+          </p>
         </Col>
       </Row>
     </PageWrapper>

--- a/src/user-portal/pages/events/OneEvent.js
+++ b/src/user-portal/pages/events/OneEvent.js
@@ -58,28 +58,28 @@ function OneEvent({ events, updateEvents, init, campaign }) {
             src={image?.url || "/img/fallback-img.png"}
             style={{
               width: "100%",
-              height:200,
+              height: 200,
               // ...(image?.url ? { minHeight: 200 } : { height: 200 }),
-              objectFit: "cover",
+              objectFit: "contain",
               borderRadius: 10,
               marginBottom: 10,
             }}
             alt={"event"}
           />
           <div>
-            <h6 className="body-font" style={{ fontWeight: "", color: "black" }}>
+            {/* <h6 className="small-font" style={{ fontWeight: "", color: "black" }}>
               <span>Date</span>
-              {event?.event_type && (
-                // <div style={{ marginTop: 10 }}>
-                <small style={{ marginLeft: 5 }}>({event?.event_type})</small>
-                // </div>
-              )}
-            </h6>
+            </h6> */}
 
-            <p className="text-sm fw-medium text-accent-3">
+            <p className="body-font fw-medium text-accent-3">
               <span>{formatDate(start_date_and_time)}</span>
             </p>
           </div>
+          {event?.event_type && (
+            <div style={{ marginTop: 10, color: "var(--app-main-color)" }}>
+              <p>{event?.event_type}</p>
+            </div>
+          )}
 
           {external_link && (
             <div


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [X] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**

- [X] One event page now looks like the event page on the user portal 
- [X] Type of event also comes before the date on the event cards
<img width="1417" alt="Screen Shot 2024-03-05 at 1 10 59 PM" src="https://github.com/massenergize/massenergize-campaigns/assets/26961591/9254fb8e-c56a-4094-85a4-d866bb2646c1">

