### PR TITLE
Feat: Bigger section images, benefit now scrolls, no modal etc

### DIFF
--- a/src/assets/styles/mobile-only.css
+++ b/src/assets/styles/mobile-only.css
@@ -1,6 +1,10 @@
 @media only screen and (max-width: 767px) {
   /* -- SPT THEME ---- */
 
+  .spt-img-for-contain { 
+    object-fit: contain !important;
+    border-radius: 0px !important;
+  }
   .mob-width-auto { 
     width: auto !important;
   }

--- a/src/assets/styles/pc-only.scss
+++ b/src/assets/styles/pc-only.scss
@@ -2,6 +2,9 @@
   --site-logo: 100px;
 }
 @media only screen and (min-width: 768px) {
+  .spt-img-for-contain { 
+    height: 500px !important;
+  }
   .partner-img {
     height: 100px;
   }

--- a/src/components/themes/sptV2/EligibilitySection.js
+++ b/src/components/themes/sptV2/EligibilitySection.js
@@ -41,7 +41,7 @@ function EligibilitySection({ section, technology, themeKey, cImage, cDescriptio
         // style={{ "--my-custom-margin": 0, display: "flex", alignItems: "center", justifyContent: "end" }}
       >
         <img
-          className="spt-s-img "
+          className="spt-s-img spt-img-for-contain"
           src={media?.url}
           alt="Community Solar"
           style={{ "--my-custom-margin": "20px 0px", objectFit: "contain" }}

--- a/src/components/themes/sptV2/SPTV2AboutCampaign.js
+++ b/src/components/themes/sptV2/SPTV2AboutCampaign.js
@@ -14,7 +14,7 @@ function SPTV2AboutCampaign({ section, technology, themeKey, cImage, cDescriptio
   const theme = getTheme(themeKey);
 
   const renderImage = () => {
-    return <img className="spt-s-img" src={cImage?.url} alt="Community Solar" />;
+    return <img className="spt-s-img " src={cImage?.url} alt="Community Solar" />;
   };
   return (
     <div style={{ marginTop: 40 }}>
@@ -73,7 +73,7 @@ function SPTV2AboutCampaign({ section, technology, themeKey, cImage, cDescriptio
         </div>
         <div className="col-md-6 spt-section-img-area mobile-margin " style={{ "--justify-content": "end" }}>
           <img
-            className="spt-s-img "
+            className="spt-s-img spt-img-for-contain"
             src={media?.url}
             alt="Community Solar"
             style={{ "--my-custom-margin": "20px 0px", objectFit: "contain" }}

--- a/src/components/themes/sptV2/SPTV2AboutSection.js
+++ b/src/components/themes/sptV2/SPTV2AboutSection.js
@@ -39,10 +39,10 @@ function SPTV2AboutSection({ technology, themeKey }) {
         // style={{ "--my-custom-margin": 0, display: "flex", alignItems: "center", justifyContent: "end" }}
       >
         <img
-          className="spt-s-img "
+          className="spt-s-img"
           src={image?.url}
           alt="Community Solar"
-          style={{ "--my-custom-margin": "20px 0px" }}
+          style={{ "--my-custom-margin": "20px 0px", background:'red' }}
         />
       </div>
     </SPTSectionComponent>

--- a/src/components/themes/sptV2/SPTV2Entry.js
+++ b/src/components/themes/sptV2/SPTV2Entry.js
@@ -95,7 +95,8 @@ function SPTV2Entry() {
   const overviewChunks = intoChunks(overviewItems, 4);
 
   const scrollableBenefitsArea = useRef();
-  console.log("lets see chunks", overviewChunks);
+  const hasScrollableChunks = overviewChunks?.length > 1;
+  
   return (
     <div>
       <div ref={heroArea}>
@@ -138,15 +139,17 @@ function SPTV2Entry() {
       </div>
       {/* ------ BENEFITS----------- */}
       <div ref={benefitsArea} className="spt-section-padding spt-section-margin-top">
-        <SPTSectionTitle>{overviewTitle || overview?.title?.text}</SPTSectionTitle>
         <div className="mobile-margin" style={{ marginTop: 40, "--my-custom-margin": "10px 0px" }}></div>
 
         <div style={{ display: "flex", padding: "20px 0px" }}>
-          <ArrowButtons
-            arrowStyle={{ color: theme?.color }}
-            containerRef={scrollableBenefitsArea}
-            style={{ marginLeft: "auto" }}
-          />
+          <SPTSectionTitle>{overviewTitle || overview?.title?.text}</SPTSectionTitle>
+          {hasScrollableChunks && (
+            <ArrowButtons
+              arrowStyle={{ color: theme?.color }}
+              containerRef={scrollableBenefitsArea}
+              style={{ marginLeft: "auto" }}
+            />
+          )}
         </div>
 
         <div
@@ -154,7 +157,7 @@ function SPTV2Entry() {
           style={{ display: "flex", flexDirection: "row", flexWrap: "nowrap", overflowX: "scroll" }}
         >
           {overviewChunks?.map((chunks) => (
-            <Col md={12} lg={12} className="spt-benefits-part">
+            <Col md={12} lg={12} xs={12} sm={12} className="spt-benefits-part">
               {chunks?.map((overview) => {
                 return (
                   <div className="spt-benefits-item" key={overview?.id} style={{ marginBottom: 10 }}>

--- a/src/components/themes/sptV2/SPTV2Entry.js
+++ b/src/components/themes/sptV2/SPTV2Entry.js
@@ -18,7 +18,9 @@ import { CAMPAIGN_TEMPLATE_KEYS, getPlaceholderURL, getTheme, PlaceholderImageUR
 import SPTContactSection from "./SPTContactSection";
 import EligibilitySection from "./EligibilitySection";
 import SPTV2AboutCampaign from "./SPTV2AboutCampaign";
-import { fetchUrlParams, scrollIntoView } from "../../../utils/utils";
+import { fetchUrlParams, intoChunks, scrollIntoView } from "../../../utils/utils";
+import { ArrowButtons } from "../../pieces/ArrowButtons";
+import { Col } from "react-bootstrap";
 
 function SPTV2Entry() {
   const goalsArea = useRef(null);
@@ -90,6 +92,10 @@ function SPTV2Entry() {
     scrollToSection(section);
   }, [salt]);
 
+  const overviewChunks = intoChunks(overviewItems, 4);
+
+  const scrollableBenefitsArea = useRef();
+  console.log("lets see chunks", overviewChunks);
   return (
     <div>
       <div ref={heroArea}>
@@ -134,22 +140,38 @@ function SPTV2Entry() {
       <div ref={benefitsArea} className="spt-section-padding spt-section-margin-top">
         <SPTSectionTitle>{overviewTitle || overview?.title?.text}</SPTSectionTitle>
         <div className="mobile-margin" style={{ marginTop: 40, "--my-custom-margin": "10px 0px" }}></div>
-        <div className="spt-benefits-part">
-          {overviewItems?.map((overview) => {
-            return (
-              <div className="spt-benefits-item" key={overview?.id} style={{ marginBottom: 10 }}>
-                {overview?.image && <img src={overview?.image?.url} alt="Benefit" />}
-                <div>
-                  <h5 style={{}}>{overview?.title}</h5>
-                  <p
-                    style={{ color: theme?.darkText }}
-                    className="spt-body-font"
-                    dangerouslySetInnerHTML={{ __html: overview?.description }}
-                  ></p>
-                </div>
-              </div>
-            );
-          })}
+
+        <div style={{ display: "flex", padding: "20px 0px" }}>
+          <ArrowButtons
+            arrowStyle={{ color: theme?.color }}
+            containerRef={scrollableBenefitsArea}
+            style={{ marginLeft: "auto" }}
+          />
+        </div>
+
+        <div
+          ref={scrollableBenefitsArea}
+          style={{ display: "flex", flexDirection: "row", flexWrap: "nowrap", overflowX: "scroll" }}
+        >
+          {overviewChunks?.map((chunks) => (
+            <Col md={12} lg={12} className="spt-benefits-part">
+              {chunks?.map((overview) => {
+                return (
+                  <div className="spt-benefits-item" key={overview?.id} style={{ marginBottom: 10 }}>
+                    {overview?.image && <img src={overview?.image?.url} alt="Benefit" />}
+                    <div>
+                      <h5 style={{}}>{overview?.title}</h5>
+                      <p
+                        style={{ color: theme?.darkText }}
+                        className="spt-body-font"
+                        dangerouslySetInnerHTML={{ __html: overview?.description }}
+                      ></p>
+                    </div>
+                  </div>
+                );
+              })}
+            </Col>
+          ))}
         </div>
       </div>
       {/* <div className="spt-section-padding spt-section-margin-top">

--- a/src/components/themes/sptV2/components/hero/Hero.js
+++ b/src/components/themes/sptV2/components/hero/Hero.js
@@ -18,7 +18,7 @@ const Hero = ({ themeKey }) => {
     slidesToShow: 1,
     slidesToScroll: 1,
     autoplay: true,
-    autoplaySpeed: 3000, //Waiting time for next slide
+    autoplaySpeed: 10000, //Waiting time for next slide
   };
   const images = (campaign?.media ||[])?.map(item => item?.media?.url)
   // const images = [

--- a/src/components/themes/sptV2/components/hero/hero.css
+++ b/src/components/themes/sptV2/components/hero/hero.css
@@ -23,6 +23,7 @@
   height: 100%;
   background: rgba(0, 0, 0, 0.5); /* Semi-transparent overlay */
   z-index: 5; /* Below the content but above the background images */
+  pointer-events: none;
 }
 
 .hero-slide {

--- a/src/index.css
+++ b/src/index.css
@@ -70,7 +70,7 @@ body {
   border-radius: 10px;
   padding: 20px;
   display: flex;
-
+  height:max-content;
   align-items: start;
   margin-right: 2%;
 }

--- a/src/user-portal/pages/landing-page/LandingPage.js
+++ b/src/user-portal/pages/landing-page/LandingPage.js
@@ -94,7 +94,9 @@ function LandingPage({
   useEffect(() => {
     init(campaignId, (justLoadedCampaign, passed) => {
       if (passed) {
-        tellUsWhereYouAreFrom(justLoadedCampaign);
+        const isNotSPTV2 =
+          justLoadedCampaign?.template_key !== CAMPAIGN_TEMPLATE_KEYS.SINGLE_TECHNOLOGY_CAMPAIGN_SPT_V2;
+        if (isNotSPTV2) tellUsWhereYouAreFrom(justLoadedCampaign);
         setPageTitle(justLoadedCampaign?.title);
       }
       setMounted(true);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -8,6 +8,14 @@ import {IS_CANARY, IS_LOCAL, IS_PROD} from "../config/environment";
 
 const LANG_CODE_TO_DATE_OBJ = { en: enUS, es, pt: ptBR }; // means when a new language is approved, we wld have to add it in here as well
 
+
+export const intoChunks = (arr, chunkSize) => { 
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    chunks.push(arr.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
 export const getCountryFromCode = (code) => {
   return (code?.split("-")[1] || "US").toLowerCase();
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

- [x]  No community select modal 
- [x] Blown up images 
- [x] Slower carousel 
- [x] Benefit area also scrolls

![Screenshot 2024-10-21 at 13 23 06](https://github.com/user-attachments/assets/829ac426-c235-49e5-a901-4576f9bb72fa)

![Screenshot 2024-10-21 at 13 23 24](https://github.com/user-attachments/assets/dd52022d-b0e3-47fb-ab88-d475bbc4ebe3)

![Screenshot 2024-10-21 at 13 23 37](https://github.com/user-attachments/assets/20284169-c8d6-44c4-9b4d-b7cb9372a7e7)




<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

<!-- - [ ] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch -->
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: https://github.com/massenergize/massenergize-campaigns/blob/main/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Other information:**
